### PR TITLE
Redirect to the canonical site URL before going to GitHub, so that we ha...

### DIFF
--- a/wafer/context_processors.py
+++ b/wafer/context_processors.py
@@ -20,3 +20,11 @@ def menu_info(request):
         'WAFER_MENUS': menus,
     }
     return context
+
+
+def registration_settings(request):
+    '''Expose selected settings to templates'''
+    context = {}
+    for setting in ('WAFER_GITHUB_CLIENT_ID',):
+        context[setting] = getattr(settings, setting, None)
+    return context

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -123,6 +123,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.messages.context_processors.messages',
     'wafer.context_processors.site_info',
     'wafer.context_processors.menu_info',
+    'wafer.context_processors.registration_settings',
 )
 
 INSTALLED_APPS = (


### PR DESCRIPTION
...ve the right Referrer

We are serving on:
- http://za.pycon.org/
- https://za.pycon.org/
- http://www.za.pycon.org/
- https://www.za.pycon.org/

but GitHub only wants people coming from the first one.
