### PR TITLE
Add individual views for sponsors.

### DIFF
--- a/wafer/sponsors/templates/wafer.sponsors/sponsor.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsor.html
@@ -1,0 +1,5 @@
+{% extends "wafer/base.html" %}
+{% block content %}
+<h1>{{ object.name }}</h1>
+{{ object.description_html|safe }}
+{% endblock %}

--- a/wafer/sponsors/urls.py
+++ b/wafer/sponsors/urls.py
@@ -1,12 +1,14 @@
 from django.conf.urls import patterns, url
 
 from wafer.sponsors.views import (
-    ShowSponsors, ShowPackages)
+    ShowSponsors, SponsorView, ShowPackages)
 
 urlpatterns = patterns(
     '',
     url(r'^$', ShowSponsors.as_view(),
         name='wafer_sponsors'),
+    url(r'^(?P<pk>\d+)/$', SponsorView.as_view(), name='wafer_sponsor'),
     url(r'^packages/$', ShowPackages.as_view(),
         name='wafer_sponsorship_packages'),
+
 )

--- a/wafer/sponsors/views.py
+++ b/wafer/sponsors/views.py
@@ -1,4 +1,5 @@
 from django.views.generic.list import ListView
+from django.views.generic import DetailView
 
 from wafer.sponsors.models import Sponsor, SponsorshipPackage
 
@@ -9,6 +10,11 @@ class ShowSponsors(ListView):
 
     def get_queryset(self):
         return Sponsor.objects.all().order_by('packages')
+
+
+class SponsorView(DetailView):
+    template_name = 'wafer.sponsors/sponsor.html'
+    model = Sponsor
 
 
 class ShowPackages(ListView):


### PR DESCRIPTION
This is so one can directly link to pages for sponsors from elsewhere (e.g. the menu, like we did in PyConZA 2012).
