### PR TITLE
Prepend http to homepage urls which have no scheme specified

### DIFF
--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -36,7 +36,7 @@
         {% spaceless %}
         <h1>
             {% if profile.homepage %}
-                <a href="{{ profile.homepage }}">
+                <a href="{{ profile.homepage_url }}">
             {% endif %}
             {{ object.get_full_name|default:object.username }}
             {% if profile.homepage %}


### PR DESCRIPTION
We don't enforce that the entered homepage has a proper schema specified, which leads to suprising links when rendering the user templates. This tries to ensure we render homepages with a schema if it's not present.
