### PR TITLE
Disable user profile post_save callback when restoring data via loaddata

### DIFF
--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -56,8 +56,8 @@ class UserProfile(models.Model):
         return self.homepage
 
 
-def create_user_profile(sender, instance, created, **kwargs):
-    if kwargs['raw']:
+def create_user_profile(sender, instance, created, raw=False, **kwargs):
+    if raw:
         return
     if created:
         UserProfile.objects.create(user=instance)


### PR DESCRIPTION
As mentioned in the django docs, access to related fields should be disabled when deserializing data via loaddata.

AFAICT, we only need to disable the create_user_profile callback, as done here.
