### PR TITLE
Replace query-string syntax with urlconf approach

### DIFF
--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -22,15 +22,15 @@
 <div class="pagination">
     <ul>
         {% if page_obj.has_previous %}
-        <li><a href="page{{ page_obj.previous_page_number }}">&laquo;</a></li>
+        <li><a href="{% url 'wafer_users_talks_page' page=page_obj.previous_page_number %}">&laquo;</a></li>
         {% else %}
         <li class="disabled"><a href="#">&laquo;</a></li>
         {% endif %}
         {% for page in paginator.page_range %}
-        <li><a href="page{{ page }}">{{ page }}</a></li>
+        <li><a href="{% url 'wafer_users_talks_page' page=page %}">{{ page }}</a></li>
         {% endfor %}
         {% if page_obj.has_next %}
-        <li><a href="page{{ page_obj.next_page_number }}">&raquo;</a></li>
+        <li><a href="{% url 'wafer_users_talks_page' page=page_obj.next_page_number %}">&raquo;</a></li>
         {% else %}
         <li class="disabled"><a href="#">&raquo;</a></li>
         {% endif %}

--- a/wafer/talks/urls.py
+++ b/wafer/talks/urls.py
@@ -6,7 +6,7 @@ from wafer.talks.views import (
 urlpatterns = patterns(
     '',
     url(r'^$', UsersTalks.as_view(), name='wafer_users_talks'),
-    url(r'^page(?P<page>\d+)$', UsersTalks.as_view(),
+    url(r'^page/(?P<page>\d+)$', UsersTalks.as_view(),
         name='wafer_users_talks_page'),
     url(r'^new/$', TalkCreate.as_view(), name='wafer_talk_submit'),
     url(r'^(?P<pk>\d+)/$', TalkView.as_view(), name='wafer_talk'),

--- a/wafer/users/templates/wafer.users/users.html
+++ b/wafer/users/templates/wafer.users/users.html
@@ -12,15 +12,15 @@
 <div class="pagination">
     <ul>
         {% if page_obj.has_previous %}
-        <li><a href="page{{ page_obj.previous_page_number }}">&laquo;</a></li>
+        <li><a href="{% url 'wafer_users_page' page=page_obj.previous_page_number %}">&laquo;</a></li>
         {% else %}
         <li class="disabled"><a href="#">&laquo;</a></li>
         {% endif %}
         {% for page in paginator.page_range %}
-        <li><a href="page{{ page }}">{{ page }}</a></li>
+        <li><a href="{% url 'wafer_users_page' page=page %}">{{ page }}</a></li>
         {% endfor %}
         {% if page_obj.has_next %}
-        <li><a href="page{{ page_obj.next_page_number }}">&raquo;</a></li>
+        <li><a href="{% url 'wafer_users_page' page=page_obj.next_page_number %}">&raquo;</a></li>
         {% else %}
         <li class="disabled"><a href="#">&raquo;</a></li>
         {% endif %}

--- a/wafer/users/urls.py
+++ b/wafer/users/urls.py
@@ -7,7 +7,7 @@ urlpatterns = patterns(
     '',
     url(r'^$', UsersView.as_view(),
         name='wafer_users'),
-    url(r'^page(?P<page>\d+)$', UsersView.as_view(),
+    url(r'^page/(?P<page>\d+)$', UsersView.as_view(),
         name='wafer_users_page'),
     url(r'^(?P<username>[\w.@+-]+)/$', ProfileView.as_view(),
         name='wafer_user_profile'),


### PR DESCRIPTION
The query string syntax we're using for paginated content is going to be rather tricky to duplicate with a static set of pages. This changes things so pagination is url-based, which is a lot simpler for generating a static site.

This currently duplicates the default page as /X/page1 - we can work around that if desired, although I'm not sure if the cosmetic issue is that important.

This will also require a fix in the pyconza2013 site templates.
