### PR TITLE
Makes Edit Mugshot button align properly with the user avatar

### DIFF
--- a/wafer/static/css/wafer.css
+++ b/wafer/static/css/wafer.css
@@ -9,6 +9,7 @@
 
 #profile-avatar img {
 	position: relative;
+	margin-bottom: 10px;
 }
 
 #profile-avatar .popover {


### PR DESCRIPTION
Adding 10px bottom margin will make the edit avatar button align correctly with the profile avatar of user
![screenshot from 2014-05-29 00 13 09](https://cloud.githubusercontent.com/assets/1151263/3109323/685e21b8-e698-11e3-97d2-36dabac3e907.png)
