### PR TITLE
Fixes alligment issue with profile links in user profile page

### DIFF
--- a/wafer/static/css/wafer.css
+++ b/wafer/static/css/wafer.css
@@ -19,6 +19,12 @@
 	display: none;
 }
 
+.profile-links li{
+	list-style: none;
+	display: inline-block;
+	margin-left: 5px;
+}
+
 /* Icons float to the right of the menu */
 .nav li.icon {
    float: right;

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -23,15 +23,15 @@
     </div>
     <div class="span10">
         {% if user = object or user.is_staff %}
-        <div class="pull-right btn-group btn-group-vertical">
-            <a href="{% url 'wafer_user_edit' object.username %}" class="btn">{% trans 'Edit User' %}</a>
-            <a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn">{% trans 'Edit Profile' %}</a>
+        <ul class="pull-right btn-group btn-group-vertical profile-links">
+            <li><a href="{% url 'wafer_user_edit' object.username %}" class="btn">{% trans 'Edit User' %}</a></li>
+            <li><a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn">{% trans 'Edit Profile' %}</a></li>
             {# These are only relevant to the user, not staff #}
             {% if user = object %}
-                <a href="{% url 'wafer_registration_submit' %}" class="btn">{% trans 'Register' %}</a>
-                <a href="{% url 'wafer_talk_submit' %}" class="btn">{% trans 'Submit Talk Proposal' %}</a>
+                <li><a href="{% url 'wafer_registration_submit' %}" class="btn">{% trans 'Register' %}</a></li>
+                <li><a href="{% url 'wafer_talk_submit' %}" class="btn">{% trans 'Submit Talk Proposal' %}</a></li>
             {% endif %}
-        </div>
+        </ul>
         {% endif %}
         {% spaceless %}
         <h1>


### PR DESCRIPTION
The links to various parts on profile in profile page is not displayed in a line, this will make them display as menu in line
![screenshot from 2014-05-29 00 32 48](https://cloud.githubusercontent.com/assets/1151263/3109577/fd05ed4e-e69a-11e3-8e47-2daa6f5cd13f.png)
