### PR TITLE
Drop duplicate check for pages, since disjoint schedule items can be useful

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -58,7 +58,6 @@ def find_duplicate_schedule_items():
     """Find talks / pages assigned to mulitple schedule items"""
     duplicates = []
     seen_talks = {}
-    seen_pages = {}
     for item in ScheduleItem.objects.all():
         if item.talk and item.talk in seen_talks:
             duplicates.append(item)
@@ -66,12 +65,9 @@ def find_duplicate_schedule_items():
                 duplicates.append(seen_talks[item.talk])
         else:
             seen_talks[item.talk] = item
-        if item.page and item.page in seen_pages:
-            duplicates.append(item)
-            if seen_pages[item.page] not in duplicates:
-                duplicates.append(seen_pages[item.page])
-        else:
-            seen_pages[item.page] = item
+        # We currently allow duplicate pages for cases were we need disjoint
+        # schedule items, like multiple open space sessions on different
+        # days and similar cases. This may be revisited later
     return duplicates
 
 

--- a/wafer/schedule/tests/test_schedule.py
+++ b/wafer/schedule/tests/test_schedule.py
@@ -688,13 +688,14 @@ class ValidationTests(TestCase):
                                             page_id=page1.pk)
         item3.slots.add(slot1)
         item4 = ScheduleItem.objects.create(venue=venue2,
-                                            page_id=page1.pk)
+                                            talk_id=talk.pk)
         item4.slots.add(slot2)
 
         duplicates = find_duplicate_schedule_items()
-        assert set(duplicates) == set([item1, item2, item3, item4])
+        assert set(duplicates) == set([item1, item2, item4])
 
         item4.page_id = page2.pk
+        item4.talk_id = None
         item4.save()
 
         duplicates = find_duplicate_schedule_items()


### PR DESCRIPTION
As discussed on irc, this allows duplicate pages in schedule items so we can have disjoint sets of schedule items referencing a single page (Open Spaces, etc.)
