### PR TITLE
Ignore multiple matches for a given email address

### DIFF
--- a/wafer/tickets/views.py
+++ b/wafer/tickets/views.py
@@ -85,6 +85,11 @@ def import_ticket(ticket_barcode, ticket_type, email):
         user = User.objects.get(email=email, ticket=None)
     except User.DoesNotExist:
         user = None
+    except User.MultipleObjectsReturned:
+        # We're can't uniquely identify the user to associate this ticket
+        # with, so leave it for them to figure out via the 'claim ticket'
+        # interface
+        user = None
 
     ticket = Ticket.objects.create(
         barcode=ticket_barcode,


### PR DESCRIPTION
We don't enforce uniqueness of an email address anywhere, so it's entirely feasible for multiple users to match the query used in the tickets view.

I don't think there's a better course of action in this case than bailing out of ticket auto-allocation and letting the user sort it out via the "claim ticket" interface.
