### PR TITLE
Fix Travis builds.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django<=1.6
 South
 django-crispy-forms
 django-nose


### PR DESCRIPTION
The release of Django 1.7 broke our Travis builds. We need to pin them to Django <= 1.6.
