### PR TITLE
Avoid bombing out of loaddata if all the pages aren't there yet

### DIFF
--- a/wafer/menu.py
+++ b/wafer/menu.py
@@ -35,7 +35,7 @@ def refresh_menu_cache(**kwargs):
         # During data loads, treat this as non-fatal, since we'll come back
         # here again with hopefully all the stuff required loaded eventually
         # (we use ObjectDoesNotExist to avoid awkard circular import issues)
-        if not kwargs['raw']:
+        if not kwargs.get('raw'):
             raise e
 
 


### PR DESCRIPTION
When importing a dump with loaddata, it may fail due to calling generate_menu before all the pages related to a menu are loaded. This makes that failure non-fatal during loading, on the assumption that the final call to refresh_menu_cache will sort everything out correctly.
