### PR TITLE
Add requirement on setuptools_git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,11 @@ setup(
     include_package_data=True,
     install_requires=REQUIRES,
     dependency_links=SOURCES,
+    setup_requires = [
+        # Add setuptools-git, so we get correct behaviour for
+        # include_package_data
+        'setuptools_git >= 1.0',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Our release on pypi is missing the templates and other static content.

The easiest fix is to use a suitable setuptools plugin to ensure include_package_data finds everything, as done here.
