### PR TITLE
Update time selection helper to match Django's current behaviour

### DIFF
--- a/wafer/static/js/scheduledatetime.js
+++ b/wafer/static/js/scheduledatetime.js
@@ -19,7 +19,7 @@
                quickElement("a", quickElement("li", this, ""),
                   time.strftime(time_format), "href",
                   "javascript:DateTimeShortcuts.handleClockQuicklink(" + num +
-                  ", '" + time.strftime(time_format) + "');");
+                  ", " + i + ");");
             }
          });
       }


### PR DESCRIPTION
Django's DateTimeShortcuts changed after I wrote this helper, so it currently just inserts "NaN:NaN" as the selected time. 

This updates it to work correctly with Django 1.7, but it will break with Django 1.6. This is annoying but I don't think it's worth the bother of trying to support both here.