### PR TITLE
Bugs/document media root writable

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -55,6 +55,10 @@ Basic instructions
 #. Create the default 'Page Editors' and 'Talk Mentors' groups using
    ``manage.py wafer_add_default_groups``.
 
+#. Ensure the permissions on the MEDIA_ROOT directory are correctly set so the
+   webserver can create new files there. This location is used for files uploaded
+   for pages and sponsor information.
+
 #. Have a fun conference.
 
 Using Django 1.6 and Python 3

--- a/docs/pages.rst
+++ b/docs/pages.rst
@@ -20,7 +20,7 @@ Container pages
 ===============
 
 Container pages are created to act as parents for other pages. These should
-have minimal content, as they will typically be displayed on the site, 
+have minimal content, as they will typically not be displayed on the site,
 and should be excluded from the static site generation.
 
 Files

--- a/docs/pages.rst
+++ b/docs/pages.rst
@@ -22,3 +22,10 @@ Container pages
 Container pages are created to act as parents for other pages. These should
 have minimal content, as they will typically be displayed on the site, 
 and should be excluded from the static site generation.
+
+Files
+=====
+
+Additional files, such as images, can be uploaded so they can be referenced in page.
+These files are placed in MEDIA_ROOT/pages_files by default. This location needs to
+be writable by the webserver for uploads to work.

--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -20,3 +20,10 @@ This is used to add details of the sponsors.
 The description is can be formatted using markdown syntax.
 
 Images can be uploaded and used in the description using the files field.
+
+Files
+=====
+
+Additional files, such as images, can be uploaded so they can be referenced.
+These files are placed in MEDIA_ROOT/sponsors_files by default. This location needs to
+be writable by the webserver for uploads to work.


### PR DESCRIPTION
This adds some reminders that MEDIA_ROOT's permissions must be set correctly, since we often forget to do that.