### PR TITLE
Remove unneeded field specifier from EditPage form to make Django 1.8 happy

### DIFF
--- a/wafer/pages/views.py
+++ b/wafer/pages/views.py
@@ -15,7 +15,6 @@ class EditPage(UpdateView):
     template_name = 'wafer.pages/page_form.html'
     model = Page
     form_class = PageForm
-    fields = ['name', 'content']
 
 
 def slug(request, url):


### PR DESCRIPTION
The fields attribute in EditPage makes Django 1.8 unhappy, and doesn't seem to be required, so we drop it.

Closes #110 