### PR TITLE
Bug fix more missing load i18n tags

### DIFF
--- a/wafer/registration/templates/registration/activate.html
+++ b/wafer/registration/templates/registration/activate.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% block content %}
 <h1>{% trans 'Oops, Registration failed' %}</h1>
 <p>

--- a/wafer/registration/templates/registration/activation_complete.html
+++ b/wafer/registration/templates/registration/activation_complete.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% block content %}
 <h1>{% trans 'Activation complete' %}</h1>
 <p>

--- a/wafer/registration/templates/registration/activation_email.txt
+++ b/wafer/registration/templates/registration/activation_email.txt
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% spaceless %}
 {% url 'registration_activate' activation_key as activation_url %}
 {% url 'index' as index_url %}

--- a/wafer/registration/templates/registration/activation_email_subject.txt
+++ b/wafer/registration/templates/registration/activation_email_subject.txt
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% blocktrans with WAFER_CONFERENCE_NAME=site.name %}
 Activate your {{ WAFER_CONFERENCE_NAME }} account [{{ expiration_days }} days left]
 {% endblocktrans %}

--- a/wafer/registration/templates/registration/login.html
+++ b/wafer/registration/templates/registration/login.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
 {% block content %}

--- a/wafer/registration/templates/registration/logout.html
+++ b/wafer/registration/templates/registration/logout.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% block content %}
 <h1>{% trans 'Logged out' %}</h1>
 <p>

--- a/wafer/registration/templates/registration/registration_complete.html
+++ b/wafer/registration/templates/registration/registration_complete.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% block content %}
 <h1>{% trans 'Registration almost complete' %}</h1>
 <p>

--- a/wafer/registration/templates/registration/registration_form.html
+++ b/wafer/registration/templates/registration/registration_form.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
 {% block content %}

--- a/wafer/schedule/templates/admin/scheduleitem_list.html
+++ b/wafer/schedule/templates/admin/scheduleitem_list.html
@@ -1,4 +1,5 @@
 {% extends "admin/change_list.html" %}
+{% load i18n %}
 {# This plugs our extra validation information into the end of the content
    block #}
 {% block content %}

--- a/wafer/schedule/templates/admin/slot_list.html
+++ b/wafer/schedule/templates/admin/slot_list.html
@@ -1,4 +1,5 @@
 {% extends "admin/change_list.html" %}
+{% load i18n %}
 {# This plugs our extra validation information into the end of the content
    block #}
 {% block content %}

--- a/wafer/tickets/templates/wafer.tickets/claim.html
+++ b/wafer/tickets/templates/wafer.tickets/claim.html
@@ -1,4 +1,5 @@
 {% extends 'wafer/base.html' %}
+{% load i18n %}
 {% load crispy_forms_tags %}
 {% block content %}
 <section class="section1">


### PR DESCRIPTION
This adds {% load i18n %} tags to a bunch of templates that need them

Every easily accesible page, including those on the admin site, works with these fixes.