### PR TITLE
Use linebreak filter on bio so it's somewhat formattable

### DIFF
--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -65,7 +65,7 @@
 </div>
 {% if profile.bio %}
 <div class="well">
-{{ profile.bio }}
+{{ profile.bio|linebreaks }}
 </div>
 {% endif %}
 {% if user == object or user.is_staff %}


### PR DESCRIPTION
Currently, we don't show line breaks when showing the profile biogrpahy, which makes formatting this hard.

Arguably, this should be a markdown field, but this is at least is an improvement which doesn't require changing the database model.