### PR TITLE
Bug/issue 129 fix scheduleitem duration

### DIFF
--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -178,6 +178,25 @@ class ScheduleItem(models.Model):
         return u'%s in %s at %s' % (self.get_desc(), self.venue,
                                     self.get_start_time())
 
+    def get_duration(self):
+        """Return the total duration of the item.
+
+           This is the sum of all the slot durations."""
+        # This is intended for the pentabarf xml file
+        # It will do the wrong thing if the slots aren't
+        # contigious, which we should address sometime.
+        slots = list(self.slots.all())
+        result = {'hours': 0, 'minutes': 0}
+        if slots:
+            for slot in slots:
+                dur = slot.get_duration()
+                result['hours'] += dur['hours']
+                result['minutes'] += dur['minutes']
+            # Normalise again
+            hours, result['minutes'] = divmod(result['minutes'], 60)
+            result['hours'] += hours
+        return result
+
 
 def invalidate_check_schedule(*args, **kw):
     from wafer.schedule.admin import check_schedule

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -29,7 +29,7 @@
                     {# Not sure what to do about timezones here #}
                     <date>{{ schedule_day.day.date|date:"Y-m-d" }}T{{ row.slot.get_start_time|time:"H:i:s" }}+00:00</date>
                     <start>{{ row.slot.get_start_time|time:"H:i" }}</start>
-                    {% with dur=row.slot.get_duration %}
+                    {% with dur=items.item.get_duration %}
                         <duration>{{ dur.hours|stringformat:"02d" }}:{{ dur.minutes|stringformat:"02d" }}</duration>
                     {% endwith %}
                     <room>{{ venue.name }}</room>


### PR DESCRIPTION
Partially fixes issue #129

If we have schedule items with slots that aren't contigious, this will do the wrong thing, but we already do very much the wrong thing in that case, so this is arguably not any worse.