### PR TITLE
Include brand in navbar header

### DIFF
--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -11,8 +11,8 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-    </div>
       <a class="navbar-brand" href="{% url 'wafer_page' 'index' %}">{{ WAFER_CONFERENCE_NAME }}</a>
+    </div>
       <div class="navbar-collapse collapse" id="wafer-navbar-collapse">
         <ul class="nav navbar-nav">
         {% for item in WAFER_MENUS.items %}


### PR DESCRIPTION
This fixes the navbar being two rows when collapsed on mobiles.