### PR TITLE
Remove spaces around the person names in the pentabarf.xml file

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -61,13 +61,9 @@
                                   {% if author.userprofile.twitter_handle %}
                                   twitter="https://twitter.com/{{ author.userprofile.twitter_handle }}"
                                   {% endif %}
-                                  contact="{{ author.email }}">
-                                  {{ author.get_full_name|default:author.username }}
-                               </person>
+                                  contact="{{ author.email }}">{{ author.get_full_name|default:author.username }}</person>
                                {% else %}
-                               <person id="{{ author.pk }}">
-                                  {{ author.get_full_name|default:author.username }}
-                               </person>
+                               <person id="{{ author.pk }}">{{ author.get_full_name|default:author.username }}</person>
                                {% endif %}
                            {% endfor %}
                        </persons>
@@ -87,13 +83,9 @@
                                   {% if author.userprofile.twitter_handle %}
                                   twitter="https://twitter.com/{{ person.userprofile.twitter_handle }}"
                                   {% endif %}
-                                  contact="{{ person.email }}">
-                                  {{ person.get_full_name|default:person.username }}
-                               </person>
+                                  contact="{{ person.email }}">{{ person.get_full_name|default:person.username }}</person>
                                {% else %}
-                               <person id="{{ person.pk }}">
-                                  {{ person.get_full_name|default:person.username }}
-                               </person>
+                               <person id="{{ person.pk }}">{{ person.get_full_name|default:person.username }}</person>
                                {% endif %}
                            {% endfor %}
                         </persons>


### PR DESCRIPTION
This removes the extra spaces within the <person> tag in the pentabarf.xml file