### PR TITLE
Expose page details as description for pages in the schedule that have speakers, as being 'important' events

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -74,10 +74,11 @@
                     <abstract/>
                     {% else %}
                         <title>{{ items.item.get_details|escape }}</title>
-                        {# Need a good idea of what to put here for non-talk items #}
-                        <description/>
                         <type/>
                         {% if items.item.page.people.exists %}
+                        {# If there are people, we care about the description #}
+                        {# For now, we drop the raw markdown content from pages here. We probably want to sanatize this in the future #}
+                        <description>{{ items.item.page.content.raw }}</description>
                         <persons>
                            {# TODO: This should be refactored, so we don't have all this duplication #}
                            {% for person in items.item.page.people.all %}
@@ -97,6 +98,8 @@
                                {% endif %}
                            {% endfor %}
                         </persons>
+                        {% else %}
+                        <description/>
                         {% endif %}
                     {% endif %}
                     <conf_url>{{ items.item.get_url }}</conf_url>


### PR DESCRIPTION
Mainly for the video use case