### PR TITLE
Add a registration_base template for the templates we don't override

### DIFF
--- a/wafer/registration/templates/registration/registration_base.html
+++ b/wafer/registration/templates/registration/registration_base.html
@@ -1,0 +1,1 @@
+{% extends 'wafer/base.html' %}


### PR DESCRIPTION
While  89b54ef  fixes the problem of not finding our templates, we don't override all the templates django-registration provides, and it's still possible to trigger an error when accessing one of the default templates because of django-registration's assumption of where the "base.html" template lives.

The easiest way to trigger this is setting "REGISTRATION_OPEN" to False, since we don't provide our own 'registration_closed' template.

This overrides django-registration's 'registration_base.html' template to avoid the issue.
