### PR TITLE
Fix the Supported version list in install.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Installation
 
    * The name will be the conference's name.
 
-4. wafer uses the Django caching infrastructure in several places, so
+4. Wafer uses the Django caching infrastructure in several places, so
    the cache table needs to be created using ``manage.py createcachetable``.
 
 5. Create the default 'Page Editors' and 'Talk Mentors' groups using

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,7 +48,7 @@ Basic instructions
      is not the case, override the wafer/registration/activation_email.txt
      template.
 
-#. wafer uses the Django caching infrastructure in several places, so
+#. Wafer uses the Django caching infrastructure in several places, so
    the cache table needs to be created using ``manage.py createcachetable``.
 
 #. Create the default 'Page Editors' and 'Talk Mentors' groups using

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Supported versions
 ==================
 
-wafer supports Django 1.7 and 1.8 and python 2.7, 3.4 and 3.5
+Wafer supports Django 1.7 and 1.8 and python 2.7, 3.4 and 3.5.
 
 Requirements
 ============

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,8 +5,7 @@ Installation
 Supported versions
 ==================
 
-wafer supports Django 1.6 and 1.7 and python 2.6 and 2.7.
-Note that Django 1.7 only supports python 2.7.
+wafer supports Django 1.7 and 1.8 and python 2.7, 3.4 and 3.5
 
 Requirements
 ============


### PR DESCRIPTION
We fixed the list in README.rst, but not the docs elsewhere.

Pull request #165 strips out the south references, so this doesn't touch that.