### PR TITLE
Add missing change_talk permission to Talk.Meta

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -29,6 +29,7 @@ class Talk(models.Model):
     class Meta:
         permissions = (
             ("view_all_talks", "Can see all talks"),
+            ("change_talk", "Can update talks"),
         )
 
     TALK_STATUS = (


### PR DESCRIPTION
The "change_talk" permission is used in the can_edit function, and also
in the management script that creates some standard roles, but it's
actually never defined. Herewith fixed.

Signed-off-by: martin f. krafft <madduck@madduck.net>