### PR TITLE
talks: Give corresponding_author permission like other authors

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -110,10 +110,16 @@ class Talk(models.Model):
     pending = property(fget=lambda x: x.status == PENDING)
     reject = property(fget=lambda x: x.status == REJECTED)
 
+    def _is_among_authors(self, user):
+        if self.corresponding_author.username == user.username:
+            return True
+        # not chaining with logical-or to avoid evaluation of the queryset
+        return self.authors.filter(username=user.username).exists()
+
     def can_view(self, user):
         if user.has_perm('talks.view_all_talks'):
             return True
-        if self.authors.filter(username=user.username).exists():
+        if self._is_among_authors(user):
             return True
         if self.accepted:
             return True
@@ -127,7 +133,7 @@ class Talk(models.Model):
         if user.has_perm('talks.change_talk'):
             return True
         if self.pending:
-            if self.authors.filter(username=user.username).exists():
+            if self._is_among_authors(user):
                 return True
         return False
 


### PR DESCRIPTION
The corresponding author of a talk needs not be in the list of authors,
and this is a good separation, allowing conference organisers to create
talks for invited speakers etc.

However, post-creation, unless a staff member, the corresponding author
won't have edit access to the talk, which is herewith fixed.

Signed-off-by: martin f. krafft <madduck@madduck.net>