### PR TITLE
talks: Display corresponding author

### DIFF
--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext as _
 
 from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit, HTML
+from crispy_forms.layout import Submit, HTML, Div, Field
 from markitup.widgets import MarkItUpWidget
 
 from wafer.talks.models import Talk
@@ -25,6 +25,24 @@ class TalkForm(forms.ModelForm):
                             _('Delete')))))
         else:
             self.helper.add_input(submit_button)
+        # insert before authors
+        # TODO: this is *YUK*, but if we add the field to Meta.fields below,
+        # then we can disable the widget, sure, but it'd still load all the 
+        # data, and we'd need to validate that the submitted form isn't trying
+        # to change the data if someone bypasses (removes) the HTML disabled
+        # tag. The following is basically display-only as the input field
+        # has no name.
+        self.helper.layout.insert(TalkForm.Meta.fields.index('authors'),
+                Div(
+                    HTML('<label class="control-label" for="id_corresponding_author">Corresponding author: </label>'),
+                    Div(
+                        HTML('<input id="id_corresponding_author" class="textinput textInput form-control" type="text" value="%s" readonly/>'
+                            % instance.corresponding_author.get_full_name()),
+                        **{'class':'controls'}
+                        ),
+                    **{'class':'form-group','id':'id_corresponding_author'}
+                    )
+                )
 
     class Meta:
         model = Talk

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -9,6 +9,14 @@
     {% endif %}
 </h1>
 <div>
+    {% if can_edit %}
+    <p>
+    {% with submitter=object.corresponding_author %}
+    Submitter:
+    <a href="{% url 'wafer_user_profile' username=submitter.username %}">{{ submitter.get_full_name|default:submitter.username }}</a>
+    {% endwith %}
+    </p>
+    {% endif %}
     <p>
     {% blocktrans count counter=object.authors.count %}
     Speaker:


### PR DESCRIPTION
As the corresponding author isn't even necessarily included in the authors list, and it's not clear from the authors list who the corresponding author is, make this field visible (read-only) to people who can edit a talk anyway.