### PR TITLE
Private talk notes

### DIFF
--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -12,7 +12,12 @@ from wafer.talks.models import Talk
 
 class TalkForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user')
         super(TalkForm, self).__init__(*args, **kwargs)
+
+        if not self.user.has_perm('talks.edit_private_notes'):
+            self.fields.pop('private_notes')
+
         self.helper = FormHelper(self)
         submit_button = Submit('submit', _('Submit'))
         instance = kwargs['instance']
@@ -28,7 +33,8 @@ class TalkForm(forms.ModelForm):
 
     class Meta:
         model = Talk
-        fields = ('title', 'talk_type', 'abstract', 'authors', 'notes')
+        fields = ('title', 'talk_type', 'abstract', 'authors', 'notes',
+                  'private_notes')
         widgets = {
             'abstract': MarkItUpWidget(),
             'notes': forms.Textarea(attrs={'class': 'input-xxlarge'}),

--- a/wafer/talks/migrations/0003_talk_private_notes.py
+++ b/wafer/talks/migrations/0003_talk_private_notes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talks', '0002_auto_20150813_2327'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='talk',
+            name='private_notes',
+            field=models.TextField(help_text='Note space for the conference organisers (not visible to submitter)', null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/wafer/talks/migrations/0004_edit_private_notes_permission.py
+++ b/wafer/talks/migrations/0004_edit_private_notes_permission.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talks', '0003_talk_private_notes'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='talk',
+            options={'permissions': (('view_all_talks', 'Can see all talks'), ('edit_private_notes', 'Can edit the private notes fields'))},
+        ),
+    ]

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -29,6 +29,7 @@ class Talk(models.Model):
     class Meta:
         permissions = (
             ("view_all_talks", "Can see all talks"),
+            ("edit_private_notes", "Can edit the private notes fields"),
         )
 
     TALK_STATUS = (

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -52,6 +52,11 @@ class Talk(models.Model):
         null=True, blank=True,
         help_text=_("Any notes for the conference organisers?"))
 
+    private_notes = models.TextField(
+        null=True, blank=True,
+        help_text=_("Note space for the conference organisers (not visible "
+                    "to submitter)"))
+
     status = models.CharField(max_length=1, choices=TALK_STATUS,
                               default=PENDING)
 

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -41,6 +41,13 @@
 <div class="well">
     {{ object.abstract.rendered|safe }}
 </div>
+{% if perms.edit_private_notes and object.private_notes %}
+<h2>Private notes</h2>
+<p>(The following is not visible to submitters or attendees.)</p>
+<div class="well">
+  {{ object.private_notes|urlize|linebreaks }}
+</div>
+{% endif %}
 {% if talk.talkurl_set.all %}
 <div class="well" id="urls">
    <div>{% trans "URLS" %}</div>

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -66,6 +66,11 @@ class TalkCreate(LoginRequiredMixin, CreateView):
     form_class = TalkForm
     template_name = 'wafer.talks/talk_form.html'
 
+    def get_form_kwargs(self):
+        kwargs = super(TalkCreate, self).get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
+
     def get_context_data(self, **kwargs):
         context = super(TalkCreate, self).get_context_data(**kwargs)
         context['can_submit'] = getattr(settings, 'WAFER_TALKS_OPEN', True)
@@ -88,6 +93,11 @@ class TalkUpdate(EditOwnTalksMixin, UpdateView):
     model = Talk
     form_class = TalkForm
     template_name = 'wafer.talks/talk_form.html'
+
+    def get_form_kwargs(self):
+        kwargs = super(TalkUpdate, self).get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super(TalkUpdate, self).get_context_data(**kwargs)


### PR DESCRIPTION
This addresses #117 in what I hope is an acceptable way. I did have to refactor the crispy form code a bit, but I only really made it more explicit.

The trick to remove a field from `self.fields` to hide it *and* prevent access to it (incl. preventing it from being considered after submission) seems to be standard…

I chose to allow HTML in the private note space, and to format URLs for convenience. While this isn't 100% safe I am sure, we are giving access to orga folks here…