### PR TITLE
Load Twitter boilerplate only when username defined

### DIFF
--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -113,6 +113,7 @@
 {% endblock %}
 {% block extra_foot %}
     <script type="text/javascript">
+        {% if profile.twitter_handle %}
         // Twitter boilerplate
         !function(d, s, id) {
             var js, fjs = d.getElementsByTagName(s)[0];
@@ -123,6 +124,7 @@
                 fjs.parentNode.insertBefore(js, fjs);
             }
         }(document, "script", "twitter-wjs");
+        {% endif %}
 
         $("#profile-avatar [rel=popover]").attr("data-content", $("#profile-avatar .popover-contents").html());
         $("a[rel=popover]").popover();


### PR DESCRIPTION
Unless the UserProfile specifies a Twitter username, there is no point
in loading the Twitter boilerplate. In fact, it could even be considered
wrong to do so… This makes loading the JavaScript conditional, just like
display of the Twitter buttons is conditional.

Signed-off-by: martin f. krafft <madduck@madduck.net>