### PR TITLE
Remove deprecated AUTH_PROFILE_MODULE setting

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -187,7 +187,6 @@ LOGGING = {
 
 # Django registration:
 ACCOUNT_ACTIVATION_DAYS = 7
-AUTH_PROFILE_MODULE = 'users.UserProfile'
 
 AUTH_USER_MODEL = 'auth.User'
 


### PR DESCRIPTION
The AUTH_PROFILE_MODULE setting has been removed in Django 1.7 and it
seems unused, so let's clean it up.

Ref: https://docs.djangoproject.com/en/1.9/internals/deprecation/#deprecation-removed-in-1-7

Signed-off-by: martin f. krafft <madduck@madduck.net>