### PR TITLE
Disable NULL on n:m fields (pages, sponsors)

### DIFF
--- a/wafer/pages/migrations/0003_non-null_people+files.py
+++ b/wafer/pages/migrations/0003_non-null_people+files.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0002_page_people'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='page',
+            name='files',
+            field=models.ManyToManyField(help_text='Images and other files for use in the content markdown field.', related_name='pages', to='pages.File', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='page',
+            name='people',
+            field=models.ManyToManyField(help_text='People associated with this page for display in the schedule (Session chairs, panelists, etc.)', related_name='pages', to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+    ]

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -40,12 +40,12 @@ class Page(models.Model):
                     " the site (Container pages, etc.)"),
         default=False)
     files = models.ManyToManyField(
-        File, related_name="pages", null=True, blank=True,
+        File, related_name="pages", blank=True,
         help_text=_("Images and other files for use in"
                     " the content markdown field."))
 
     people = models.ManyToManyField(settings.AUTH_USER_MODEL,
-        related_name='pages', null=True, blank=True,
+        related_name='pages', blank=True,
         help_text=_("People associated with this page for display in the"
                     " schedule (Session chairs, panelists, etc.)"))
 

--- a/wafer/sponsors/migrations/0002_non-null_files.py
+++ b/wafer/sponsors/migrations/0002_non-null_files.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sponsors', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sponsor',
+            name='files',
+            field=models.ManyToManyField(help_text='Images and other files for use in the description markdown field.', related_name='sponsors', to='sponsors.File', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='sponsorshippackage',
+            name='files',
+            field=models.ManyToManyField(help_text='Images and other files for use in the description markdown field.', related_name='packages', to='sponsors.File', blank=True),
+        ),
+    ]

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -36,7 +36,7 @@ class SponsorshipPackage(models.Model):
     description = MarkupField(
         help_text=_("Describe what the package gives the sponsor."))
     files = models.ManyToManyField(
-        File, related_name="packages", null=True, blank=True,
+        File, related_name="packages", blank=True,
         help_text=_("Images and other files for use in"
                     " the description markdown field."))
 
@@ -56,7 +56,7 @@ class Sponsor(models.Model):
     description = MarkupField(
         help_text=_("Write some nice things about the sponsor."))
     files = models.ManyToManyField(
-        File, related_name="sponsors", null=True, blank=True,
+        File, related_name="sponsors", blank=True,
         help_text=_("Images and other files for use in"
                     " the description markdown field."))
 


### PR DESCRIPTION
This patch removes the null=True attributes from the ManyToManyFields
found in the pages.Page, sponsors.Sponsor and sponsors.Sponsorpackage
models, and therefore silences the following Django warnings:

WARNINGS:
pages.Page.files: (fields.W340) null has no effect on ManyToManyField.
pages.Page.people: (fields.W340) null has no effect on ManyToManyField.
sponsors.Sponsor.files: (fields.W340) null has no effect on ManyToManyField.
sponsors.SponsorshipPackage.files: (fields.W340) null has no effect on ManyToManyField.

Signed-off-by: martin f. krafft <madduck@madduck.net>