### PR TITLE
Feature/add django reversion support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ REQUIRES = [
     'pytz',
     'requests',
     'django-medusa>=0.3.0',
+    'django-reversion>=1.10',
 ]
 
 SOURCES = []

--- a/wafer/pages/admin.py
+++ b/wafer/pages/admin.py
@@ -2,8 +2,10 @@ from django.contrib import admin
 
 from wafer.pages.models import File, Page
 
+from reversion.admin import VersionAdmin
 
-class PageAdmin(admin.ModelAdmin):
+
+class PageAdmin(VersionAdmin, admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
     list_display = ('name', 'slug', 'get_people_display_names', 'get_in_schedule')
 

--- a/wafer/pages/views.py
+++ b/wafer/pages/views.py
@@ -2,6 +2,8 @@ from django.http import Http404
 from django.core.exceptions import PermissionDenied
 from django.views.generic import DetailView, TemplateView, UpdateView
 
+from reversion import revisions
+
 from wafer.pages.models import Page
 from wafer.pages.forms import PageForm
 
@@ -15,6 +17,13 @@ class EditPage(UpdateView):
     template_name = 'wafer.pages/page_form.html'
     model = Page
     form_class = PageForm
+
+    def form_valid(self, form):
+        with revisions.create_revision():
+            result = super(EditPage, self).form_valid(form)
+            revisions.set_user(self.request.user)
+            revisions.set_comment("Page Modified")
+        return result
 
 
 def slug(request, url):

--- a/wafer/pages/views.py
+++ b/wafer/pages/views.py
@@ -18,12 +18,11 @@ class EditPage(UpdateView):
     model = Page
     form_class = PageForm
 
+    @revisions.create_revision()
     def form_valid(self, form):
-        with revisions.create_revision():
-            result = super(EditPage, self).form_valid(form)
-            revisions.set_user(self.request.user)
-            revisions.set_comment("Page Modified")
-        return result
+        revisions.set_user(self.request.user)
+        revisions.set_comment("Page Modified")
+        return super(EditPage, self).form_valid(form)
 
 
 def slug(request, url):

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -135,6 +135,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
+    'reversion',
     'django_medusa',
     'crispy_forms',
     'django_nose',

--- a/wafer/sponsors/admin.py
+++ b/wafer/sponsors/admin.py
@@ -2,7 +2,16 @@ from django.contrib import admin
 
 from wafer.sponsors.models import File, SponsorshipPackage, Sponsor
 
+from reversion.admin import VersionAdmin
 
-admin.site.register(SponsorshipPackage)
-admin.site.register(Sponsor)
+class SponsorAdmin(VersionAdmin, admin.ModelAdmin):
+    pass
+
+
+class SponsorshipPackageAdmin(VersionAdmin, admin.ModelAdmin):
+    pass
+
+
+admin.site.register(SponsorshipPackage, SponsorshipPackageAdmin)
+admin.site.register(Sponsor, SponsorAdmin)
 admin.site.register(File)

--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 
+from reversion.admin import VersionAdmin
+
 from wafer.talks.models import TalkType, Talk, TalkUrl
 
 class ScheduleListFilter(admin.SimpleListFilter):
@@ -20,14 +22,14 @@ class ScheduleListFilter(admin.SimpleListFilter):
             return queryset.filter(scheduleitem__isnull=True)
         return queryset
 
-class TalkUrlAdmin(admin.ModelAdmin):
+class TalkUrlAdmin(VersionAdmin, admin.ModelAdmin):
     list_display = ('description', 'talk', 'url')
 
 class TalkUrlInline(admin.TabularInline):
     model = TalkUrl
 
 
-class TalkAdmin(admin.ModelAdmin):
+class TalkAdmin(VersionAdmin, admin.ModelAdmin):
     list_display = ('title', 'get_corresponding_author_name',
                     'get_corresponding_author_contact', 'talk_type',
                     'get_in_schedule', 'has_url', 'status')

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -78,19 +78,19 @@ class TalkCreate(LoginRequiredMixin, CreateView):
         context['can_submit'] = getattr(settings, 'WAFER_TALKS_OPEN', True)
         return context
 
+    @revisions.create_revision()
     def form_valid(self, form):
         if not getattr(settings, 'WAFER_TALKS_OPEN', True):
             raise ValidationError  # Should this be SuspiciousOperation?
         # Eaaargh we have to do the work of CreateView if we want to set values
         # before saving
-        with revisions.create_revision():
-            self.object = form.save(commit=False)
-            self.object.corresponding_author = self.request.user
-            self.object.save()
-            revisions.set_user(self.request.user)
-            revisions.set_comment("Talk Created")
-            # Save the author information as well (many-to-many fun)
-            form.save_m2m()
+        self.object = form.save(commit=False)
+        self.object.corresponding_author = self.request.user
+        self.object.save()
+        revisions.set_user(self.request.user)
+        revisions.set_comment("Talk Created")
+        # Save the author information as well (many-to-many fun)
+        form.save_m2m()
         return HttpResponseRedirect(self.get_success_url())
 
 
@@ -109,16 +109,11 @@ class TalkUpdate(EditOwnTalksMixin, UpdateView):
         context['can_edit'] = self.object.can_edit(self.request.user)
         return context
 
+    @revisions.create_revision()
     def form_valid(self, form):
-        # Is there a better way to do this?
-        # I don't want to use RevisionMiddleware, because I think we
-        # want more control over things than that provides, but
-        # this feels clunky
-        with revisions.create_revision():
-            result = super(TalkUpdate, self).form_valid(form)
-            revisions.set_user(self.request.user)
-            revisions.set_comment("Talk Modified")
-        return result
+        revisions.set_user(self.request.user)
+        revisions.set_comment("Talk Modified")
+        return super(TalkUpdate, self).form_valid(form)
 
 
 class TalkDelete(EditOwnTalksMixin, DeleteView):
@@ -126,12 +121,11 @@ class TalkDelete(EditOwnTalksMixin, DeleteView):
     template_name = 'wafer.talks/talk_delete.html'
     success_url = reverse_lazy('wafer_page', args=('index',))
 
+    @revisions.create_revision()
     def form_valid(self, form):
-        with reversion.create_revision():
-            result = super(TalkDelete, self).form_valid(form)
-            # We don't add any metadata, as the admin site
-            # doesn't show it for deleted talks.
-        return result
+        # We don't add any metadata, as the admin site
+        # doesn't show it for deleted talks.
+        return super(TalkDelete, self).form_valid(form)
 
 
 class Speakers(ListView):

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -84,7 +84,6 @@ class TalkCreate(LoginRequiredMixin, CreateView):
         # Eaaargh we have to do the work of CreateView if we want to set values
         # before saving
         with revisions.create_revision():
-            print 'Here'
             self.object = form.save(commit=False)
             self.object.corresponding_author = self.request.user
             self.object.save()
@@ -92,7 +91,6 @@ class TalkCreate(LoginRequiredMixin, CreateView):
             revisions.set_comment("Talk Created")
             # Save the author information as well (many-to-many fun)
             form.save_m2m()
-            print 'There'
         return HttpResponseRedirect(self.get_success_url())
 
 


### PR DESCRIPTION
This uses django-reversion to track edits to talks and pages.

The history is only exposed through the admin interface. We probably want to expose it in some way for people editing pages, but I'm not sure that's required for talks. Displaying the date of last edit to people who can change talks and pages is probably a good idea.

We may want to hook this up to the Sponsors model as well. I'm not sure it makes sense for the other models we have.