### PR TITLE
Loosen Django version requirement spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 # command to install dependencies,
 install:
    # Install the right version of Django first
-   - pip install 'Django<='"$DJANGO_VERSION"
+   - pip install 'Django~='"$DJANGO_VERSION".0
    - pip install -r requirements.txt -r requirements-dev.txt
 # command to run tests
 script: NOSE_WITH_COVERAGE=1 python manage.py test


### PR DESCRIPTION
PR #188 exposed a Django version requirement in the travis spec that was
too tight. By converting from an inclusive ordered matching specifier to
the compatibility specifier, we ensure that e.g. Django 1.8.1 (or
whatever is current) will be used to fulfill a Django 1.8 dependency.

Ref: https://www.python.org/dev/peps/pep-0440/#compatible-release
Signed-off-by: martin f. krafft <madduck@madduck.net>