### PR TITLE
Add simple key-value store, and attach to users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ REQUIRES = [
     'django-nose',
     'django-registration-redux',
     'djangorestframework',
+    'jsonfield',
     'pillow',
     'pyLibravatar',
     'pytz',

--- a/wafer/kv/models.py
+++ b/wafer/kv/models.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.models import Group
+from django.db import models
+
+from jsonfield import JSONField
+
+
+class KeyValue(models.Model):
+    group = models.ForeignKey(Group)
+    key = models.CharField(max_length=64, db_index=True)
+    value = JSONField()
+
+    def __unicode__(self):
+        return u'KV(%s, %s, %r)' % (self.group.name, self.key, self.value)

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -143,6 +143,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'easy_select2',
     'wafer',
+    'wafer.kv',
     'wafer.registration',
     'wafer.talks',
     'wafer.schedule',

--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -18,6 +18,7 @@ class AdminTalkForm(forms.ModelForm):
         self.fields['corresponding_author'].label_from_instance = render_author
 
 
+
 class ScheduleListFilter(admin.SimpleListFilter):
     title = _('in schedule')
     parameter_name = 'schedule'
@@ -35,8 +36,10 @@ class ScheduleListFilter(admin.SimpleListFilter):
             return queryset.filter(scheduleitem__isnull=True)
         return queryset
 
+
 class TalkUrlAdmin(VersionAdmin, admin.ModelAdmin):
     list_display = ('description', 'talk', 'url')
+
 
 class TalkUrlInline(admin.TabularInline):
     model = TalkUrl
@@ -50,8 +53,8 @@ class TalkAdmin(VersionAdmin, admin.ModelAdmin):
     list_filter = ('status', 'talk_type', ScheduleListFilter)
 
     inlines = [
-              TalkUrlInline,
-              ]
+        TalkUrlInline,
+    ]
     form = AdminTalkForm
 
 

--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -45,14 +45,23 @@ class TalkUrlInline(admin.TabularInline):
     model = TalkUrl
 
 
+class KVPairsInline(admin.StackedInline):
+    model = Talk.kv.through
+    verbose_name_plural = 'Key Value pairs'
+    list_display = ('key', 'value')
+    extra = 1
+
+
 class TalkAdmin(VersionAdmin, admin.ModelAdmin):
     list_display = ('title', 'get_corresponding_author_name',
                     'get_corresponding_author_contact', 'talk_type',
                     'get_in_schedule', 'has_url', 'status')
     list_editable = ('status',)
     list_filter = ('status', 'talk_type', ScheduleListFilter)
+    exclude = ('kv',)
 
     inlines = [
+        KVPairsInline,
         TalkUrlInline,
     ]
     form = AdminTalkForm

--- a/wafer/talks/migrations/0005_add_kv.py
+++ b/wafer/talks/migrations/0005_add_kv.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kv', '__first__'),
+        ('talks', '0004_edit_private_notes_permission'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='talk',
+            name='kv',
+            field=models.ManyToManyField(to='kv.KeyValue'),
+        ),
+    ]

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -6,6 +6,8 @@ from django.utils.encoding import python_2_unicode_compatible
 
 from markitup.fields import MarkupField
 
+from wafer.kv.models import KeyValue
+
 
 # constants to make things clearer elsewhere
 ACCEPTED = 'A'
@@ -75,6 +77,8 @@ class Talk(models.Model):
         settings.AUTH_USER_MODEL, related_name='talks',
         help_text=_(
             "The speakers presenting the talk."))
+
+    kv = models.ManyToManyField(KeyValue)
 
     def __str__(self):
         return u'%s: %s' % (self.corresponding_author, self.title)

--- a/wafer/users/admin.py
+++ b/wafer/users/admin.py
@@ -5,15 +5,48 @@ from django.contrib.auth import get_user_model
 from wafer.users.models import UserProfile
 
 
+# User-centric
+
 class UserProfileInline(admin.StackedInline):
     model = UserProfile
     can_delete = False
     verbose_name_plural = 'profile'
+    exclude = ('kv',)
 
 
 class UserAdmin(UserAdmin):
     inlines = (UserProfileInline,)
 
 
+# UserProfile-centric (a hack, to customise KV Pairs)
+
+class KVPairsInline(admin.StackedInline):
+    model = UserProfile.kv.through
+    verbose_name_plural = 'Key Value pairs'
+    list_display = ('key', 'value')
+    extra = 1
+
+
+def username(obj):
+    return obj.user.username
+
+
+def email(obj):
+    return obj.user.email
+
+
+class UserProfileAdmin(admin.ModelAdmin):
+    model = UserProfile
+    readonly_fields = ('user',)
+    exclude = ('kv',)
+    inlines = (KVPairsInline,)
+    list_select_related = ('user',)
+    list_display = (username, 'display_name', email)
+    search_fields = ('user__username', 'user__first_name', 'user__last_name',
+                     'user__email')
+
+
 admin.site.unregister(get_user_model())
 admin.site.register(get_user_model(), UserAdmin)
+
+admin.site.register(UserProfile, UserProfileAdmin)

--- a/wafer/users/forms.py
+++ b/wafer/users/forms.py
@@ -42,4 +42,4 @@ class UserProfileForm(forms.ModelForm):
 
     class Meta:
         model = UserProfile
-        exclude = ('user',)
+        exclude = ('user', 'kv')

--- a/wafer/users/migrations/0002_userprofile_kv.py
+++ b/wafer/users/migrations/0002_userprofile_kv.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kv', '__first__'),
+        ('users', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='kv',
+            field=models.ManyToManyField(to='kv.KeyValue'),
+        ),
+    ]

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -8,7 +8,6 @@ try:
     from urllib2 import urlparse
 except ImportError:
     from urllib import parse as urlparse
-from django.utils.http import urlquote
 
 from wafer.kv.models import KeyValue
 from wafer.talks.models import ACCEPTED, PENDING

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -10,12 +10,14 @@ except ImportError:
     from urllib import parse as urlparse
 from django.utils.http import urlquote
 
+from wafer.kv.models import KeyValue
 from wafer.talks.models import ACCEPTED, PENDING
 
 
 @python_2_unicode_compatible
 class UserProfile(models.Model):
     user = models.OneToOneField(User)
+    kv = models.ManyToManyField(KeyValue)
     contact_number = models.CharField(max_length=16, null=True, blank=True)
     bio = models.TextField(null=True, blank=True)
 


### PR DESCRIPTION
Fixes: #147

Simple KeyValue store implementation. Currently the admin view of this is hacky-as-hell. You can't nest inlines (and these models don't really work well in inlines, anyway), so we're probably going to have to do some major customization of the user edit form, to handle these well.