### PR TITLE
Feature/revision compare support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ REQUIRES = [
     'djangorestframework',
     'jsonfield',
     'pillow',
+    'diff-match-patch',
     'pyLibravatar',
     'pytz',
     'requests',

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -104,10 +104,9 @@ class CompareVersionAdmin(VersionAdmin):
                 continue
             else:
                 patch = generate_patch_html(revision, current, field)
-            the_diff.append('<h2>%s</h2>\n%s' % (field, patch))
+            the_diff.append((field, patch))
 
-        if not the_diff:
-            the_diff = ['<p>No differences found</p>']
+        the_diff.sort()
 
         context = {
             "title": _("Comparing current %s with revision created %s") % (
@@ -116,7 +115,7 @@ class CompareVersionAdmin(VersionAdmin):
             "opts": opts,
             "compare_list_url": reverse("%s:%s_%s_comparelist" % (self.admin_site.name, opts.app_label, opts.model_name),
                                                                   args=(quote(object_id),)),
-            "diff": '\n<p>\n'.join(the_diff),
+            "diff_list": the_diff,
         }
 
         extra_context = extra_context or {}

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -85,15 +85,21 @@ class CompareVersionAdmin(VersionAdmin):
             # between the creation of revisions. This isn't ideal,
             # but should not be a fatal error.
             # Log this?
+            missing_field = False
             try:
                 cur_val = current.field_dict[field] or ""
             except KeyError:
-                cur_val = ""
+                cur_val = "No such field in latest version"
+                missing_field = True
             try:
                 old_val = revision.field_dict[field] or ""
             except KeyError:
-                old_val = ""
-            if isinstance(cur_val, Markup):
+                old_val = "No such field in old version"
+                missing_field = True
+            if missing_field:
+                diffs = dmp.diff_main(old_val, cur_val)
+                patch =  dmp.diff_prettyHtml(diffs)
+            elif isinstance(cur_val, Markup):
                 # we roll our own diff here, so we can compare of the raw
                 # markdown, rather than the rendered result.
                 if cur_val.raw == old_val.raw:

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -1,0 +1,61 @@
+# hack'ish support for comparing a django reversion
+# hisoty object with the current state
+
+from reversion.admin import VersionAdmin
+from django.conf.urls import url
+from django.shortcuts import get_object_or_404, render
+from django.utils.translation import ugettext as _
+
+
+class CompareVersionAdmin(VersionAdmin):
+
+    compare_template = "admin/wafer.compare/compare.html"
+    compare_list_template = "admin/wafer.compare/compare_list.html"
+
+    # Add a compare button next to the History button.
+    change_form_template = "admin/wafer.compare/change_form.html"
+
+    def get_urls(self):
+         urls = super(CompareVersionAdmin, self).get_urls()
+         opts = self.model._meta
+         compare_urls = [
+               url("^([^/]+)/compare/$", self.admin_site.admin_view(self.compare_view),
+                   name='%s_%s_compare' % (opts.app_label, opts.model_name)),
+               url("^([^/]+)/comparelist/$", self.admin_site.admin_view(self.comparelist_view),
+                   name='%s_%s_comparelist' % (opts.app_label, opts.model_name)),
+         ]
+         return compare_urls + urls
+
+    def compare_view(self, request, object_id, extra_context=None):
+        """Actually compare two versions."""
+        opts = self.model._meta
+        current = get_object_or_404(self.model, pk=object_id)
+        context = {
+            "title": _("Compare %s") % current.object_repr,
+            "app_label": opts.app_label,
+            "history_url": reverse("%s:%s_%s_history" % (self.admin_site.name, opts.app_label, opts.model_name),
+                                                         args=(quote(obj.pk),)),
+        }
+
+        extra_context = extra_context or {}
+        context.update(extra_context)
+        return render(request, self.compare_template or self._get_template_list("compare.html"),
+                      context)
+
+    def comparelist_view(self, request, object_id, extra_context=None):
+        """Allow selecting versions to compare."""
+        opts = self.model._meta
+        context = {
+            "title": _("Choose version of %s to compare") % opts.verbose_name,
+            "app_label": opts.app_label,
+            "opts": opts,
+            "module_name": opts.verbose_name,
+        }
+        each_context = self.admin_site.each_context(request)
+        context.update(each_context)
+
+        extra_context = extra_context or {}
+        context.update(extra_context)
+        return render(request, self.compare_list_template or self._get_template_list("compare_list.html"),
+                      context)
+

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -81,8 +81,18 @@ class CompareVersionAdmin(VersionAdmin):
             # These exclusions really should be configurable
             if field == 'id' or field.endswith('_rendered'):
                 continue
-            cur_val = current.field_dict[field] or ""
-            old_val = revision.field_dict[field] or ""
+            # KeyError's may happen if the database structure changes
+            # between the creation of revisions. This isn't ideal,
+            # but should not be a fatal error.
+            # Log this?
+            try:
+                cur_val = current.field_dict[field] or ""
+            except KeyError:
+                cur_val = ""
+            try:
+                old_val = revision.field_dict[field] or ""
+            except KeyError:
+                old_val = ""
             if isinstance(cur_val, Markup):
                 # we roll our own diff here, so we can compare of the raw
                 # markdown, rather than the rendered result.

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -1,5 +1,5 @@
 # hack'ish support for comparing a django reversion
-# hisoty object with the current state
+# history object with the current state
 
 from diff_match_patch import diff_match_patch
 import datetime

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -89,15 +89,18 @@ class CompareVersionAdmin(VersionAdmin):
             try:
                 cur_val = current.field_dict[field] or ""
             except KeyError:
-                cur_val = "No such field in latest version"
+                cur_val = "No such field in latest version\n"
                 missing_field = True
             try:
                 old_val = revision.field_dict[field] or ""
             except KeyError:
-                old_val = "No such field in old version"
+                old_val = "No such field in old version\n"
                 missing_field = True
             if missing_field:
-                diffs = dmp.diff_main(old_val, cur_val)
+                # Ensure that the complete texts are marked as changed
+                # so new entires containing any of the marker words
+                # don't show up as differences
+                diffs = [(dmp.DIFF_DELETE, old_val), (dmp.DIFF_INSERT, cur_val)]
                 patch =  dmp.diff_prettyHtml(diffs)
             elif isinstance(cur_val, Markup):
                 # we roll our own diff here, so we can compare of the raw

--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -77,7 +77,7 @@ class CompareVersionAdmin(VersionAdmin):
         the_diff = []
         dmp = diff_match_patch()
 
-        for field in current.field_dict:
+        for field in (set(current.field_dict.keys()) | set(revision.field_dict.keys())):
             # These exclusions really should be configurable
             if field == 'id' or field.endswith('_rendered'):
                 continue

--- a/wafer/compare/templates/admin/wafer.compare/change_form.html
+++ b/wafer/compare/templates/admin/wafer.compare/change_form.html
@@ -5,7 +5,7 @@
         <a href="{% url opts|admin_urlname:'history' original.pk|admin_urlquote %}" class="historylink">{% trans "History" %}</a>
     </li>
     <li>
-       <a href="{% url opts|admin_urlname:'comparelist' original.pk|admin_urlquote %}" class="historylink">Compare Versions</a>
+       <a href="{% url opts|admin_urlname:'comparelist' original.pk|admin_urlquote %}" class="historylink">{% trans "Compare Versions" %}</a>
     </li>
     {% if has_absolute_url %}
         <li>

--- a/wafer/compare/templates/admin/wafer.compare/change_form.html
+++ b/wafer/compare/templates/admin/wafer.compare/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+{% block object-tools-items %}
+    <li>
+        <a href="{% url opts|admin_urlname:'history' original.pk|admin_urlquote %}" class="historylink">{% trans "History" %}</a>
+    </li>
+    <li>
+       <a href="{% url opts|admin_urlname:'comparelist' original.pk|admin_urlquote %}" class="historylink">Compare Versions</a>
+    </li>
+    {% if has_absolute_url %}
+        <li>
+            <a href="{% url 'admin:view_on_site' content_type_id original.pk %}" class="viewsitelink">{% trans "View on site" %}</a>
+        </li>
+    {% endif %}
+{% endblock %}

--- a/wafer/compare/templates/admin/wafer.compare/compare.html
+++ b/wafer/compare/templates/admin/wafer.compare/compare.html
@@ -1,0 +1,43 @@
+{% extends "reversion/object_history.html" %}
+{% load i18n %}
+
+
+{% block content %}
+    <div id="content-main">
+
+        <p>{% blocktrans %}Choose a date from the list below to comapre the current version to a previous version of this object.{% endblocktrans %}</p>
+
+        <div class="module">
+            {% if action_list %}
+                <table id="change-history" class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th scope="col">{% trans 'Date/time' %}</th>
+                            <th scope="col">{% trans 'User' %}</th>
+                            <th scope="col">{% trans 'Comment' %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for action in action_list %}
+                            <tr>
+                                <th scope="row"><a href="{{action.url}}">{{action.revision.date_created}}</a></th>
+                                <td>
+                                    {% if action.revision.user %}
+                                        {{action.revision.user.get_username}}
+                                        {% if action.revision.user.get_full_name %} ({{action.revision.user.get_full_name}}){% endif %}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>{{action.revision.comment|linebreaksbr|default:""}}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p>{% trans "This object doesn't have a change history. It probably wasn't added via this admin site." %}</p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+

--- a/wafer/compare/templates/admin/wafer.compare/compare.html
+++ b/wafer/compare/templates/admin/wafer.compare/compare.html
@@ -1,43 +1,17 @@
-{% extends "reversion/object_history.html" %}
-{% load i18n %}
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+       <a href="{{ compare_list_url }}">Compare</a> &rsaquo;
+        {% blocktrans with opts.verbose_name_plural|escape as name %}{{name}}{% endblocktrans %}
+    </div>
+{% endblock %}
 
 
 {% block content %}
-    <div id="content-main">
 
-        <p>{% blocktrans %}Choose a date from the list below to comapre the current version to a previous version of this object.{% endblocktrans %}</p>
+  {{ diff | safe }}
 
-        <div class="module">
-            {% if action_list %}
-                <table id="change-history" class="table table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th scope="col">{% trans 'Date/time' %}</th>
-                            <th scope="col">{% trans 'User' %}</th>
-                            <th scope="col">{% trans 'Comment' %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for action in action_list %}
-                            <tr>
-                                <th scope="row"><a href="{{action.url}}">{{action.revision.date_created}}</a></th>
-                                <td>
-                                    {% if action.revision.user %}
-                                        {{action.revision.user.get_username}}
-                                        {% if action.revision.user.get_full_name %} ({{action.revision.user.get_full_name}}){% endif %}
-                                    {% else %}
-                                        &mdash;
-                                    {% endif %}
-                                </td>
-                                <td>{{action.revision.comment|linebreaksbr|default:""}}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            {% else %}
-                <p>{% trans "This object doesn't have a change history. It probably wasn't added via this admin site." %}</p>
-            {% endif %}
-        </div>
-    </div>
 {% endblock %}
 

--- a/wafer/compare/templates/admin/wafer.compare/compare.html
+++ b/wafer/compare/templates/admin/wafer.compare/compare.html
@@ -11,7 +11,16 @@
 
 {% block content %}
 
-  {{ diff | safe }}
+{% for field, diff in diff_list %}
+<h2 id="fieldname">{{ field }}</h2>
+<div id="diff">
+   {{ diff | safe }}
+</div>
+{% empty %}
+<div id="diff">
+   <p>{% trans 'No differences found' %}</p>
+</div>
+{% endfor %}
 
 {% endblock %}
 

--- a/wafer/compare/templates/admin/wafer.compare/compare_list.html
+++ b/wafer/compare/templates/admin/wafer.compare/compare_list.html
@@ -1,0 +1,53 @@
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls %}
+
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'changelist' %}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo;
+        {% blocktrans with opts.verbose_name_plural|escape as name %}Compare {{name}}{% endblocktrans %}
+    </div>
+{% endblock %}
+
+
+{% block content %}
+    <div id="content-main">
+
+        <p>{% blocktrans %}Choose a date from the list below to compare the current version to a previous version of this object.{% endblocktrans %}</p>
+
+        <div class="module">
+            {% if action_list %}
+                <table id="change-history" class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th scope="col">{% trans 'Date/time' %}</th>
+                            <th scope="col">{% trans 'User' %}</th>
+                            <th scope="col">{% trans 'Comment' %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for action in action_list %}
+                            <tr>
+                                <th scope="row"><a href="{{action.url}}">{{action.revision.date_created}}</a></th>
+                                <td>
+                                    {% if action.revision.user %}
+                                        {{action.revision.user.get_username}}
+                                        {% if action.revision.user.get_full_name %} ({{action.revision.user.get_full_name}}){% endif %}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>{{action.revision.comment|linebreaksbr|default:""}}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p>{% trans "This object doesn't have a change history. It probably wasn't added via this admin site." %}</p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+

--- a/wafer/compare/templates/admin/wafer.compare/compare_list.html
+++ b/wafer/compare/templates/admin/wafer.compare/compare_list.html
@@ -5,8 +5,9 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo;
-        <a href="{% url 'admin:app_list' app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
         <a href="{% url opts|admin_urlname:'changelist' %}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'change' object_id %}">{{original|truncatewords:"18"}}</a> &rsaquo;
         {% blocktrans with opts.verbose_name_plural|escape as name %}Compare {{name}}{% endblocktrans %}
     </div>
 {% endblock %}

--- a/wafer/pages/admin.py
+++ b/wafer/pages/admin.py
@@ -2,10 +2,10 @@ from django.contrib import admin
 
 from wafer.pages.models import File, Page
 
-from reversion.admin import VersionAdmin
+from wafer.compare.admin import CompareVersionAdmin
 
 
-class PageAdmin(VersionAdmin, admin.ModelAdmin):
+class PageAdmin(CompareVersionAdmin, admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
     list_display = ('name', 'slug', 'get_people_display_names', 'get_in_schedule')
 

--- a/wafer/pages/admin.py
+++ b/wafer/pages/admin.py
@@ -2,12 +2,15 @@ from django.contrib import admin
 
 from wafer.pages.models import File, Page
 
-from wafer.compare.admin import CompareVersionAdmin
+from wafer.compare.admin import CompareVersionAdmin, DateModifiedFilter
 
 
 class PageAdmin(CompareVersionAdmin, admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
     list_display = ('name', 'slug', 'get_people_display_names', 'get_in_schedule')
+
+    list_filter = (DateModifiedFilter,)
+
 
 
 admin.site.register(Page, PageAdmin)

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -147,9 +147,9 @@ INSTALLED_APPS = (
     'wafer.sponsors',
     'wafer.pages',
     'wafer.tickets',
+    'wafer.compare',
     # Django isn't finding the overridden templates
     'registration',
-    'wafer.compare',
 )
 
 from django.db import migrations

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -149,6 +149,7 @@ INSTALLED_APPS = (
     'wafer.tickets',
     # Django isn't finding the overridden templates
     'registration',
+    'wafer.compare',
 )
 
 from django.db import migrations

--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from reversion.admin import VersionAdmin
 from easy_select2 import select2_modelform_meta
 
+from wafer.compare.admin import CompareVersionAdmin
 from wafer.talks.models import TalkType, Talk, TalkUrl, render_author
 
 
@@ -52,7 +53,7 @@ class KVPairsInline(admin.StackedInline):
     extra = 1
 
 
-class TalkAdmin(VersionAdmin, admin.ModelAdmin):
+class TalkAdmin(CompareVersionAdmin, admin.ModelAdmin):
     list_display = ('title', 'get_corresponding_author_name',
                     'get_corresponding_author_contact', 'talk_type',
                     'get_in_schedule', 'has_url', 'status')

--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from reversion.admin import VersionAdmin
 from easy_select2 import select2_modelform_meta
 
-from wafer.compare.admin import CompareVersionAdmin
+from wafer.compare.admin import CompareVersionAdmin, DateModifiedFilter
 from wafer.talks.models import TalkType, Talk, TalkUrl, render_author
 
 
@@ -58,7 +58,7 @@ class TalkAdmin(CompareVersionAdmin, admin.ModelAdmin):
                     'get_corresponding_author_contact', 'talk_type',
                     'get_in_schedule', 'has_url', 'status')
     list_editable = ('status',)
-    list_filter = ('status', 'talk_type', ScheduleListFilter)
+    list_filter = ('status', 'talk_type', ScheduleListFilter, DateModifiedFilter)
     exclude = ('kv',)
 
     inlines = [


### PR DESCRIPTION
This adds basic support for comparing the current revision with past revisions, since that's a useful feature.

The canonical compare implementation for django-reversion is django-reversion-compare, but that's GPL licensed, so I've opted not to go down that path.

This isn't particularly featureful, and the resulting output view could use some UI love, but works reasonably well.

Currently it's hooked up for Talks and Pages, as useful test cases.

