### PR TITLE
Sponsor list rendering on arbitrary templates

### DIFF
--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -65,3 +65,7 @@ class Sponsor(models.Model):
 
     def get_absolute_url(self):
         return reverse('wafer_sponsor', args=(self.pk,))
+
+    @property
+    def logo(self):
+        return self.files.get(name='logo').item

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
@@ -1,0 +1,20 @@
+<div id="wafer-sponsors">
+    {% for package in packages %}
+    {% if package.sponsors.exists %}
+        <div>
+            <div class="package">{{ package.name }}</div>
+            <ul>
+                {% for sponsor in package.sponsors.all %}
+                    <li>
+                        {% if sponsor.logo %}
+                            <img src="{{ sponsor.logo.url }}" alt="{{ sponsor.name }}">
+                        {% else %}
+                            <span class="nologo">{{ sponsor.name }}</span>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+    {% endfor %}
+</div>

--- a/wafer/sponsors/templatetags/sponsors.py
+++ b/wafer/sponsors/templatetags/sponsors.py
@@ -1,0 +1,13 @@
+from django import template
+
+from wafer.sponsors.models import Sponsor, SponsorshipPackage
+
+register = template.Library()
+
+
+@register.inclusion_tag('wafer.sponsors/sponsors_block.html')
+def sponsors():
+    return {
+        'sponsors': Sponsor.objects.all().order_by('packages'),
+        'packages': SponsorshipPackage.objects.all().prefetch_related('files'),
+    }

--- a/wafer/templates/wafer/base.html
+++ b/wafer/templates/wafer/base.html
@@ -1,3 +1,4 @@
+{% load sponsors %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -28,6 +29,7 @@
     <h1>{{ WAFER_CONFERENCE_NAME }}</h1>
 {% endblock %}
     </div>
+    {% sponsors %}
     <script src="{{ STATIC_URL }}jquery/dist/jquery.min.js"></script>
     <script src="{{ STATIC_URL }}bootstrap/dist/js/bootstrap.min.js"></script>
     {% block extra_foot %}{% endblock %}


### PR DESCRIPTION
e.g. the base template

This lets you put sponsor lists on every page, quite easily.

I went with a template tag, rather than a global context addition, so that it can be included anywhere, trivially.