### PR TITLE
Fix (and simplify) the DEBUG media server

### DIFF
--- a/wafer/urls.py
+++ b/wafer/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, patterns, url
+from django.conf.urls.static import static
 from django.conf import settings
 from django.contrib import admin
 
@@ -23,8 +24,5 @@ urlpatterns = patterns(
 
 # Serve media
 if settings.DEBUG:
-    urlpatterns += patterns(
-        '',
-        url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-            {'document_root': settings.MEDIA_ROOT}),
-    )
+    urlpatterns += static(
+        settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/wafer/urls.py
+++ b/wafer/urls.py
@@ -17,12 +17,12 @@ urlpatterns = patterns(
     (r'^markitup/', include('markitup.urls')),
     (r'^schedule/', include('wafer.schedule.urls')),
     (r'^tickets/', include('wafer.tickets.urls')),
-
-    # Pages occupy the entire URL space, and must come last
-    url(r'', include('wafer.pages.urls')),
 )
 
 # Serve media
 if settings.DEBUG:
     urlpatterns += static(
         settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Pages occupy the entire URL space, and must come last
+urlpatterns.append(url(r'', include('wafer.pages.urls')))


### PR DESCRIPTION
It needs to come before the catchall in the URL router.