### PR TITLE
Customizeable talk form

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -265,6 +265,9 @@ WAFER_REGISTRATION_MODE = 'ticket'
 # For REGISTRATION_MODE == 'form', the form to present
 WAFER_REGISTRATION_FORM = 'wafer.users.forms.ExampleRegistrationForm'
 
+# The form used for talk submission
+WAFER_TALK_FORM = 'wafer.talks.forms.TalkForm'
+
 # Ticket registration with Quicket
 # WAFER_TICKET_SECRET = "i'm a shared secret"
 

--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -1,5 +1,7 @@
 from django import forms
+from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.utils.module_loading import import_string
 from django.utils.translation import ugettext as _
 
 from crispy_forms.bootstrap import FormActions
@@ -9,6 +11,10 @@ from markitup.widgets import MarkItUpWidget
 from easy_select2.widgets import Select2Multiple
 
 from wafer.talks.models import Talk, render_author
+
+
+def get_talk_form_class():
+    return import_string(settings.WAFER_TALK_FORM)
 
 
 class TalkForm(forms.ModelForm):

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -16,7 +16,7 @@ from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from rest_framework.response import Response
 
 from wafer.talks.models import Talk, ACCEPTED
-from wafer.talks.forms import TalkForm
+from wafer.talks.forms import get_talk_form_class
 from wafer.talks.serializers import TalkSerializer
 from wafer.users.models import UserProfile
 
@@ -71,8 +71,10 @@ class TalkView(DetailView):
 
 class TalkCreate(LoginRequiredMixin, CreateView):
     model = Talk
-    form_class = TalkForm
     template_name = 'wafer.talks/talk_form.html'
+
+    def get_form_class(self):
+        return get_talk_form_class()
 
     def get_form_kwargs(self):
         kwargs = super(TalkCreate, self).get_form_kwargs()
@@ -103,8 +105,10 @@ class TalkCreate(LoginRequiredMixin, CreateView):
 
 class TalkUpdate(EditOwnTalksMixin, UpdateView):
     model = Talk
-    form_class = TalkForm
     template_name = 'wafer.talks/talk_form.html'
+
+    def get_form_class(self):
+        return get_talk_form_class()
 
     def get_form_kwargs(self):
         kwargs = super(TalkUpdate, self).get_form_kwargs()


### PR DESCRIPTION
Similarly to the way we customized registration forms, allow replacing the talk form.

This lets conferences tweak labelling and layout.