### PR TITLE
Replace "Register" with "Sign up" in account creation

### DIFF
--- a/wafer/registration/forms.py
+++ b/wafer/registration/forms.py
@@ -10,7 +10,7 @@ class RegistrationFormHelper(FormHelper):
 
     def __init__(self, *args, **kwargs):
         super(RegistrationFormHelper, self).__init__(*args, **kwargs)
-        self.add_input(Submit('submit', _('Register')))
+        self.add_input(Submit('submit', _('Sign up')))
 
 
 class LoginFormHelper(FormHelper):

--- a/wafer/registration/templates/registration/registration_form.html
+++ b/wafer/registration/templates/registration/registration_form.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
 {% block content %}
-<h1>{% trans 'Registration' %}</h1>
+<h1>{% trans 'Sign up' %}</h1>
 {% wafer_form_helper 'wafer.registration.forms.RegistrationFormHelper' as form_helper %}
 {% crispy form form_helper %}
 {% endblock %}

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -66,7 +66,7 @@
           </li>
           {% elif not WAFER_HIDE_LOGIN %}
           <li><a href="{% url 'auth_login' %}">
-              {% trans 'Register / Log In' %}
+              {% trans 'Sign up / Log In' %}
           </a></li>
           {% endif %}
         </ul>


### PR DESCRIPTION
Registering for an account on the wafer site is not registering attendance for the conference. This could avoid confusion.