### PR TITLE
Allow the registration form to provide some initial values

### DIFF
--- a/wafer/users/forms.py
+++ b/wafer/users/forms.py
@@ -80,3 +80,7 @@ class ExampleRegistrationForm(forms.Form):
             if item.value is True:
                 return True
         return False
+
+    def initial_values(self, user):
+        """Set default values, based on the user"""
+        return {'debconf': True}

--- a/wafer/users/views.py
+++ b/wafer/users/views.py
@@ -95,8 +95,9 @@ class RegistrationView(EditOneselfMixin, FormView):
     def get_initial(self):
         saved = self.get_queryset()
 
-        initial = {}
         form = self.get_form_class()()
+        initial = form.initial_values(self.get_user())
+
         for field in form.fields:
             try:
                 initial[field] = saved.get(key=field).value


### PR DESCRIPTION
I want to be able to use things like the username, and user's name as default values for fields in the DebConf registration from.