### PR TITLE
Give talk types a defined order

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -28,6 +28,9 @@ class TalkType(models.Model):
     def __str__(self):
         return u'%s' % (self.name,)
 
+    class Meta:
+        ordering = ['id']
+
 
 @python_2_unicode_compatible
 class Talk(models.Model):


### PR DESCRIPTION
Again, some kind of ordering field, could be handy. (And also, restricting some talk types to admins-only, such as plenary sessions)

But this gets the job done with minimal disruption.