### PR TITLE
Make redirect_profile useful for anonymous users

### DIFF
--- a/wafer/registration/views.py
+++ b/wafer/registration/views.py
@@ -1,6 +1,7 @@
 import urllib
 
 from django.contrib.auth import login
+from django.contrib.auth.views import redirect_to_login
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -17,7 +18,7 @@ def redirect_profile(request):
         return HttpResponseRedirect(reverse('wafer_user_profile',
                                             args=(request.user.username,)))
     else:
-        return HttpResponseRedirect(reverse('wafer_page', args=('index',)))
+        return redirect_to_login(next=reverse(redirect_profile))
 
 
 def github_login(request):


### PR DESCRIPTION
If the user isn't logged in, we can still (eventually) send them to the profile.

This allows us to reference `/accounts/profile/` from external documentation, making the redirect useful outside wafer.

Currently we only use it as a convenient destination for forms etc.