### PR TITLE
Bugs/hookup password change

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -130,7 +130,6 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.admin',
     'reversion',
     'django_medusa',
     'crispy_forms',
@@ -150,6 +149,7 @@ INSTALLED_APPS = (
     'wafer.compare',
     # Django isn't finding the overridden templates
     'registration',
+    'django.contrib.admin',
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/wafer/users/templates/wafer.users/edit_user.html
+++ b/wafer/users/templates/wafer.users/edit_user.html
@@ -3,5 +3,6 @@
 {% load crispy_forms_tags %}
 {% block content %}
 <h1>{% trans 'Edit User:' %}</h1>
+<li><a href="{% url 'auth_password_change' %}" class="btn btn-default">{% trans 'Change Password' %}</a></li>
 {% crispy form %}
 {% endblock %}


### PR DESCRIPTION
The password change functionality is currently not very discoverable.

This ensures we use the django-registration templates (so we have the right styling) and adds a "change password" button to the edit user page (this choice is debatable - it should possibly be on the main user page, but that already has a large number of buttons already).

We should probably also add a discoverable link to the password reset form at some stage.