### PR TITLE
Bugs/issue 219 duplicate pages

### DIFF
--- a/wafer/pages/admin.py
+++ b/wafer/pages/admin.py
@@ -7,7 +7,8 @@ from wafer.compare.admin import CompareVersionAdmin, DateModifiedFilter
 
 class PageAdmin(CompareVersionAdmin, admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
-    list_display = ('name', 'slug', 'get_people_display_names', 'get_in_schedule')
+    list_display = ('name', 'slug', 'get_absolute_url',
+                    'get_people_display_names', 'get_in_schedule')
 
     list_filter = (DateModifiedFilter,)
 

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -64,6 +64,8 @@ class Page(models.Model):
         url = "/".join(self.get_path())
         return reverse('wafer_page', args=(url,))
 
+    get_absolute_url.short_description = 'page url'
+
     def get_in_schedule(self):
         if self.scheduleitem_set.all():
             return True


### PR DESCRIPTION
This adds a custom validation check to prevent duplicate pages being created, since the existing unique_together constraint is insufficient to enforce it.

For reasons of sanity, this also adds a check for circular references in a page's parent hierachy.

Closes #219 