### PR TITLE
Bugs/update dependencies drop universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [bdist_wheel]
-universal = 1
+# Although we're perfectly portable, our dependenices differ between py2 and py3, so we can't offer universal wheels.
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=1.6',
+    'Django>=1.7',
     'django-crispy-forms',
     'django-nose',
     'django-registration-redux',
@@ -17,27 +17,20 @@ REQUIRES = [
     'django-medusa>=0.3.0',
     'django-reversion>=1.10',
     'django-easy-select2',
+    'django-markitup>=2.2.2',
+    'markdown>=2.5',
 ]
 
 SOURCES = []
 
 REQUIRES2 = [
     'pydns',
-    # markdown 2.5 drops support for Python 2.6. Django 1.7 doesn't
-    # support 2.6 either, so we can drop this restriction
-    # when we move to Django 1.7
-    'markdown<2.5',
-    # We need django-markitup >= 2.2.2 to support django 1.7 properly
-    # on python 2
-    'django-markitup>=2.2.1',
 ]
 
 SOURCES2 = []
 
 REQUIRES3 = [
     'py3dns',
-    'markdown>=2.5',
-    'django-markitup>=2.2',
 ]
 
 SOURCES3 = []


### PR DESCRIPTION
Because of the pydns / py3dns split, we can't generate universal wheels, so drop that.

Cleanup the dependancies around markdown and django-markitup while we're here, since we no longer need to support Django 1.6.