### PR TITLE
Fix endif tag

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -83,7 +83,7 @@
                                <person id="{{ person.pk }}"
                                   {% if author.userprofile.twitter_handle %}
                                   twitter="https://twitter.com/{{ person.userprofile.twitter_handle }}"
-                                  { endif %}
+                                  {% endif %}
                                   contact="{{ person.email }}">{{ person.userprofile.display_name }}</person>
                                {% else %}
                                <person id="{{ person.pk }}">{{ person.userprofile.display_name }}</person>


### PR DESCRIPTION
As seen recently on za.pycon.org

```
Internal Server Error: /schedule/pentabarf.xml
Traceback (most recent call last):
  File "/home/pyconza/pyconza2016/ve/lib/python3.4/site-packages/django/template/base.py", line 338, in parse
    compile_func = self.tags[command]
KeyError: 'endfor'
```

This fixes the corresponding template typo.