### PR TITLE
Copy base_fields before mutating

### DIFF
--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -1,3 +1,5 @@
+import copy
+
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -25,6 +27,7 @@ class TalkForm(forms.ModelForm):
 
         if not (settings.WAFER_PUBLIC_ATTENDEE_LIST
                 or self.user.has_perm('talks.change_talk')):
+            self.base_fields = copy.deepcopy(self.base_fields)
             self.base_fields['authors'].limit_choices_to = {
                 'id__in': [author.id for author in authors]}
 

--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -27,6 +27,7 @@ class TalkForm(forms.ModelForm):
 
         if not (settings.WAFER_PUBLIC_ATTENDEE_LIST
                 or self.user.has_perm('talks.change_talk')):
+            # copy base_fields because it's a shared class attribute
             self.base_fields = copy.deepcopy(self.base_fields)
             self.base_fields['authors'].limit_choices_to = {
                 'id__in': [author.id for author in authors]}


### PR DESCRIPTION
base_fields is an attribute on the class, not instances, so mutations to
its contents are permanent.

Usually, one isn't supposed to mutate base_fields, and rather mutate
fields. However, limit_choices_to is applied during ModelForm's
__init__, before we can see fields.