### PR TITLE
Only show the change password button on the user's edit password page

### DIFF
--- a/wafer/users/templates/wafer.users/edit_user.html
+++ b/wafer/users/templates/wafer.users/edit_user.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% block content %}
 <h1>{% trans 'Edit User:' %}</h1>
-{% if user.has_usable_password %}
+{% if profile_user == user and profile_user.has_usable_password %}
   <ul>
     <li>
       <a href="{% url 'auth_password_change' %}" class="btn btn-default">


### PR DESCRIPTION
An iteraction I missed in #238 

It isn't particularly sensible to show a "change password" button on every edit user screen. The change password form only changes the logged in user's password, but when shown on every screen, it appears to be an option to change the password for any user with a password. This only affects people with suitable edit user permissions, since ordinary users can't access the 'edit user' page of other people, but it is still not great UI.