### PR TITLE
Bugs/issue 247 avoid iteritems

### DIFF
--- a/wafer/registration/sso.py
+++ b/wafer/registration/sso.py
@@ -66,7 +66,7 @@ def _configure_user(user, name, email, profile_fields):
 
     profile = user.userprofile
     if profile_fields:
-        for k, v in profile_fields.iteritems():
+        for k, v in profile_fields.items():
             setattr(profile, k, v)
     profile.save()
 

--- a/wafer/schedule/templates/admin/scheduleitem_list.html
+++ b/wafer/schedule/templates/admin/scheduleitem_list.html
@@ -11,7 +11,7 @@
           {% if errors.clashes %}
           <h3>{% trans "Clashes" %}</h3>
           <ul>
-             {% for pos, items in errors.clashes.iteritems %}
+             {% for pos, items in errors.clashes.items %}
              <li>{{ pos.0 }} at {{ pos.1.get_start_time|time:"H:i" }} --
                  {% for item in items %}
                      {{ item }},
@@ -47,7 +47,7 @@
           {% if errors.venues %}
           <h3>{% trans "Venues assigned on days they are not available" %}</h3>
           <ul>
-             {% for venue, items in errors.venues.iteritems %}
+             {% for venue, items in errors.venues.items %}
              <li>{{ venue }} --
                  {% for item in items %}
                     {{ item }},

--- a/wafer/users/views.py
+++ b/wafer/users/views.py
@@ -170,7 +170,7 @@ class RegistrationView(EditOneselfMixin, FormView):
         user = self.get_user()
         group = self.get_kv_group()
 
-        for key, value in form.cleaned_data.iteritems():
+        for key, value in form.cleaned_data.items():
             try:
                 pair = saved.get(key=key)
                 pair.value = value


### PR DESCRIPTION
Closes #247 by replacing iteritems with items.

None of the mentioned uses of iteritems are performance critical, so I don't see any need for a more complicated fix.