### PR TITLE
Day ID is a useless navigation indicator

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -9,7 +9,7 @@
                     <a class="dropdown-toggle" data-toggle="dropdown"
                        href="#" role="button" aria-haspopup="true"
                        aria-expanded="true">
-                        Day {{ day.id }}
+                        {{ day.date }}
                         <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu"
@@ -17,7 +17,7 @@
                         {% for day in days %}
                             <li>
                                 <a href="{% url 'admin:schedule_editor' day.id %}">
-                                    Day {{ day.id }} ({{ day.date }})
+                                    {{ day.date }} (Day {{ day.id }})
                                 </a>
                             </li>
                         {% endfor %}


### PR DESCRIPTION
It's order is useless for navigation, while actual date is a lot
more useful.

@stefanor was complaining about this.