### PR TITLE
Remove KV pairs from admin, makes it dog slow

### DIFF
--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -19,7 +19,6 @@ class AdminTalkForm(forms.ModelForm):
         self.fields['corresponding_author'].label_from_instance = render_author
 
 
-
 class ScheduleListFilter(admin.SimpleListFilter):
     title = _('in schedule')
     parameter_name = 'schedule'
@@ -46,13 +45,6 @@ class TalkUrlInline(admin.TabularInline):
     model = TalkUrl
 
 
-class KVPairsInline(admin.StackedInline):
-    model = Talk.kv.through
-    verbose_name_plural = 'Key Value pairs'
-    list_display = ('key', 'value')
-    extra = 1
-
-
 class TalkAdmin(CompareVersionAdmin, admin.ModelAdmin):
     list_display = ('title', 'get_corresponding_author_name',
                     'get_corresponding_author_contact', 'talk_type',
@@ -62,7 +54,6 @@ class TalkAdmin(CompareVersionAdmin, admin.ModelAdmin):
     exclude = ('kv',)
 
     inlines = [
-        KVPairsInline,
         TalkUrlInline,
     ]
     form = AdminTalkForm

--- a/wafer/users/admin.py
+++ b/wafer/users/admin.py
@@ -26,17 +26,5 @@ def email(obj):
     return obj.user.email
 
 
-class UserProfileAdmin(admin.ModelAdmin):
-    model = UserProfile
-    readonly_fields = ('user',)
-    exclude = ('kv',)
-    list_select_related = ('user',)
-    list_display = (username, 'display_name', email)
-    search_fields = ('user__username', 'user__first_name', 'user__last_name',
-                     'user__email')
-
-
 admin.site.unregister(get_user_model())
 admin.site.register(get_user_model(), UserAdmin)
-
-admin.site.register(UserProfile, UserProfileAdmin)

--- a/wafer/users/admin.py
+++ b/wafer/users/admin.py
@@ -18,15 +18,6 @@ class UserAdmin(UserAdmin):
     inlines = (UserProfileInline,)
 
 
-# UserProfile-centric (a hack, to customise KV Pairs)
-
-class KVPairsInline(admin.StackedInline):
-    model = UserProfile.kv.through
-    verbose_name_plural = 'Key Value pairs'
-    list_display = ('key', 'value')
-    extra = 1
-
-
 def username(obj):
     return obj.user.username
 
@@ -39,7 +30,6 @@ class UserProfileAdmin(admin.ModelAdmin):
     model = UserProfile
     readonly_fields = ('user',)
     exclude = ('kv',)
-    inlines = (KVPairsInline,)
     list_select_related = ('user',)
     list_display = (username, 'display_name', email)
     search_fields = ('user__username', 'user__first_name', 'user__last_name',


### PR DESCRIPTION
Putting KV pairs in admin didn't help admin anything, and made admin unbearably slow.

Every time you view anything with a KV pair on it, it has to display every KV pair in the database in the dropdown list. Not ideal.