### PR TITLE
Feature/drop django 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,12 @@ python:
    - "3.4"
    - "3.5"
 env:
-   - DJANGO_VERSION=1.7 TESTDB=sqlite
-   - DJANGO_VERSION=1.7 TESTDB=postgres
    - DJANGO_VERSION=1.8 TESTDB=sqlite
    - DJANGO_VERSION=1.8 TESTDB=postgres
    - DJANGO_VERSION=1.9 TESTDB=sqlite
    - DJANGO_VERSION=1.9 TESTDB=postgres
 matrix:
    exclude:
-      # Django 1.7 doesn't support python 3.5
-      - python: "3.5"
-        env: DJANGO_VERSION=1.7 TESTDB=sqlite
-      - python: "3.5"
-        env: DJANGO_VERSION=1.7 TESTDB=postgres
       # Django 1.9 doesn't support 3.3
       - python: "3.3"
         env: DJANGO_VERSION=1.9 TESTDB=sqlite

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Available on `readthedocs.org`_.
 Supported Django versions
 =========================
 
-Wafer supports Django 1.7 and Django 1.8.
+Wafer supports Django 1.8 and Django 1.9.
 
 
 Installation

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Supported versions
 ==================
 
-Wafer supports Django 1.7 and 1.8 and python 2.7, 3.4 and 3.5.
+Wafer supports Django 1.8 and 1.9 and python 2.7, 3.4 and 3.5.
 
 Requirements
 ============

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=1.7',
+    'Django>=1.8',
     'django-crispy-forms',
     'django-nose',
     'django-registration-redux',


### PR DESCRIPTION
As mentioned in #260 and #254, continuing to support Django 1.7 is becoming problematic.

This drops support for Django 1.7 and upates the documenation accordingly.

