### PR TITLE
Restrict django-reversion to before 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ REQUIRES = [
     'pytz',
     'requests',
     'django-medusa>=0.3.0',
-    'django-reversion>=1.10',
+    'django-reversion>=1.10,<2.0',
     'django-easy-select2',
     'django-markitup>=2.2.2',
     'markdown>=2.5',


### PR DESCRIPTION
As a short term measure until we drop Django 1.7, restrict django-reversion to something that still supports that verison.