### PR TITLE
Expose scheduling information on talk page.

### DIFF
--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -209,7 +209,7 @@ class ScheduleItem(models.Model):
     def get_duration_minutes(self):
         """Return the duration in total number of minutes."""
         duration = self.get_duration()
-        return int(duration['hours']*60 + duration['minutes'])
+        return int(duration['hours'] * 60 + duration['minutes'])
 
 
 def invalidate_check_schedule(*args, **kw):

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -206,6 +206,11 @@ class ScheduleItem(models.Model):
             result['hours'] += hours
         return result
 
+    def get_duration_minutes(self):
+        """Return the duration in total number of minutes."""
+        duration = self.get_duration()
+        return int(duration['hours']*60 + duration['minutes'])
+
 
 def invalidate_check_schedule(*args, **kw):
     from wafer.schedule.admin import check_schedule

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -26,15 +26,15 @@
     {% if object.get_in_schedule %}
     {% for schedule in object.scheduleitem_set.all %}
     <p>
-    Room:
+    {% trans 'Room:' %}
     {{ schedule.venue }}
     </p>
     <p>
-    Time:
+    {% trans 'Time:' %}
     {{ schedule.get_start_time }}
     </p>
     <p>
-    Duration:
+    {% trans 'Duration:' %}
     {{ schedule.get_duration.hours|floatformat }}h{{ schedule.get_duration.minutes|floatformat }}
     </p>
     {% endfor %}

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -23,6 +23,22 @@
     Type:
     {{ object.talk_type.name|default:'Talk' }}
     </p>
+    {% if object.get_in_schedule %}
+    {% for schedule in object.scheduleitem_set.all %}
+    <p>
+    Room:
+    {{ schedule.venue }}
+    </p>
+    <p>
+    Time:
+    {{ schedule.get_start_time }}
+    </p>
+    <p>
+    Duration:
+    {{ schedule.get_duration.hours }} hour(s)
+    </p>
+    {% endfor %}
+    {% endif %}
 </div>
 {% if user.is_staff %}
 <div>

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -35,7 +35,7 @@
     </p>
     <p>
     Duration:
-    {{ schedule.get_duration.hours }} hour(s)
+    {{ schedule.get_duration.hours|floatformat }}h{{ schedule.get_duration.minutes|floatformat }}
     </p>
     {% endfor %}
     {% endif %}

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -35,7 +35,7 @@
     </p>
     <p>
     {% trans 'Duration:' %}
-    {{ schedule.get_duration.hours|floatformat }}h{{ schedule.get_duration.minutes|floatformat }}
+    {{ schedule.get_duration_minutes }} {% trans 'mins' %}
     </p>
     {% endfor %}
     {% endif %}

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -20,22 +20,30 @@
     {% endfor %}
     </p>
     <p>
+    {% blocktrans with talk_type=object.talk_type.name|default:'Talk' %}
     Type:
-    {{ object.talk_type.name|default:'Talk' }}
+    {{ talk_type }}
+    {% endblocktrans %}
     </p>
     {% if object.get_in_schedule %}
     {% for schedule in object.scheduleitem_set.all %}
     <p>
-    {% trans 'Room:' %}
-    {{ schedule.venue }}
+    {% blocktrans with venue=schedule.venue %}
+    Room:
+    {{ venue }}
+    {% endblocktrans %}
     </p>
     <p>
-    {% trans 'Time:' %}
-    {{ schedule.get_start_time }}
+    {% blocktrans with start_time=schedule.get_start_time %}
+    Time:
+    {{ start_time }}
+    {% endblocktrans %}
     </p>
     <p>
-    {% trans 'Duration:' %}
-    {{ schedule.get_duration_minutes }} {% trans 'mins' %}
+    {% blocktrans with minutes=schedule.get_duration_minutes %}
+    Duration:
+    {{ minutes }} mins
+    {% endblocktrans %}
     </p>
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
When ppl click on a talk name, it would be nice to see some information
about when and where it is happening. The default wafer templates do not
expose this information.