### PR TITLE
Bugs/issue 170 make talk notes more visible

### DIFF
--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -26,13 +26,14 @@ Talk Mentors
 ============
 
 The ``Talk Mentors`` group has permission to view all talk submissions and
-to edit talks.
+to edit talks. They also have permission to view the notes submitted along
+with a talk.
 
 Managing talks from the admin interface
 =======================================
 
-From the admin interface talks can be modified, and marked as accepted or
-not accepted as required.
+From the admin interface talks can be modified, and marked as accepted,
+cancelled or not accepted as required.
 
 
 Talk urls

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -48,7 +48,7 @@
     {% endfor %}
     {% endif %}
 </div>
-{% if user.is_staff or perms.view_all_talks %}
+{% if user.is_staff or perms.talks.view_all_talks %}
 <div>
     <p>
     {% trans 'Status:' %}
@@ -67,14 +67,14 @@
 <div class="well">
     {{ object.abstract.rendered|safe }}
 </div>
-{% if perms.view_all_talks or user.is_superuser %}
+{% if perms.talks.view_all_talks or user.is_superuser %}
 <h2>Talk Notes</h2>
 <p>(The following is not visible to attendees.)</p>
 <div class="well">
   {{ object.notes|urlize|linebreaks }}
 </div>
 {% endif %}
-{% if perms.edit_private_notes and object.private_notes %}
+{% if perms.talks.edit_private_notes and object.private_notes %}
 <h2>Private notes</h2>
 <p>(The following is not visible to submitters or attendees.)</p>
 <div class="well">

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -67,6 +67,13 @@
 <div class="well">
     {{ object.abstract.rendered|safe }}
 </div>
+{% if perms.view_all_talks or user.is_superuser %}
+<h2>Talk Notes</h2>
+<p>(The following is not visible to attendees.)</p>
+<div class="well">
+  {{ object.notes|urlize|linebreaks }}
+</div>
+{% endif %}
 {% if perms.edit_private_notes and object.private_notes %}
 <h2>Private notes</h2>
 <p>(The following is not visible to submitters or attendees.)</p>

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -68,15 +68,19 @@
     {{ object.abstract.rendered|safe }}
 </div>
 {% if perms.talks.view_all_talks or user.is_superuser %}
+{% blocktrans %}
 <h2>Talk Notes</h2>
 <p>(The following is not visible to attendees.)</p>
+{% endblocktrans %}
 <div class="well">
   {{ object.notes|urlize|linebreaks }}
 </div>
 {% endif %}
 {% if perms.talks.edit_private_notes and object.private_notes %}
+{% blocktrans %}
 <h2>Private notes</h2>
 <p>(The following is not visible to submitters or attendees.)</p>
+{% endblocktrans %}
 <div class="well">
   {{ object.private_notes|urlize|linebreaks }}
 </div>

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -48,7 +48,7 @@
     {% endfor %}
     {% endif %}
 </div>
-{% if user.is_staff %}
+{% if user.is_staff or perms.view_all_talks %}
 <div>
     <p>
     {% trans 'Status:' %}

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -68,6 +68,7 @@
     {{ object.abstract.rendered|safe }}
 </div>
 {% if perms.talks.view_all_talks or user.is_superuser %}
+{% if talk.notes %}
 {% blocktrans %}
 <h2>Talk Notes</h2>
 <p>(The following is not visible to attendees.)</p>
@@ -75,6 +76,7 @@
 <div class="well">
   {{ object.notes|urlize|linebreaks }}
 </div>
+{% endif %}
 {% endif %}
 {% if perms.talks.edit_private_notes and object.private_notes %}
 {% blocktrans %}

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -214,7 +214,6 @@ class TalkNoteViewTests(TestCase):
             'username': 'editor', 'password': 'editor_password',
         })
 
-
     def test_view_notes_accepted_superuser(self):
         create_user('super', superuser=True)
         self.check_talk_view(self.talk_a, True, True, auth={

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -129,7 +129,7 @@ class TalkViewTests(TestCase):
             'username': 'reviewer', 'password': 'reviewer_password',
         })
 
-    def test_view_rejected_has_view_all_perm(self):
+    def test_view_cancelled_has_view_all_perm(self):
         create_user('reviewer', perms=['view_all_talks'])
         self.check_talk_view(self.talk_c, 200, auth={
             'username': 'reviewer', 'password': 'reviewer_password',

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -30,6 +30,8 @@ def create_talk(title, status, username):
     talk = Talk.objects.create(
         title=title, status=status, corresponding_author_id=user.id)
     talk.authors.add(user)
+    talk.notes = "Some notes for talk %s" % title
+    talk.private_notes = "Some private notes for talk %s" % title
     talk.save()
     return talk
 
@@ -137,6 +139,85 @@ class TalkViewTests(TestCase):
         create_user('reviewer', perms=['view_all_talks'])
         self.check_talk_view(self.talk_p, 200, auth={
             'username': 'reviewer', 'password': 'reviewer_password',
+        })
+
+
+class TalkNoteViewTests(TestCase):
+    def setUp(self):
+        self.talk_a = create_talk("Talk A", ACCEPTED, "author_a")
+        self.talk_r = create_talk("Talk R", REJECTED, "author_r")
+        self.client = Client()
+
+    def check_talk_view(self, talk, notes_visible, private_notes_visible,
+                        auth=None):
+        if auth is not None:
+            self.client.login(**auth)
+        response = self.client.get(
+            reverse('wafer_talk', kwargs={'pk': talk.pk}))
+        if notes_visible:
+            self.assertTrue('Some notes for talk' in str(response))
+        else:
+            self.assertFalse('Some notes for talk' in str(response))
+        if private_notes_visible:
+            self.assertTrue('Some private notes for talk' in str(response))
+        else:
+            self.assertFalse('Some private notes for talk' in str(response))
+
+    def test_view_notes_accepted_not_logged_in(self):
+        self.check_talk_view(self.talk_a, False, False)
+
+    def test_view_notes_accepted_author(self):
+        self.check_talk_view(self.talk_a, False, False, auth={
+            'username': 'author_a', 'password': 'author_a_password',
+        })
+
+    def test_view_notes_rejected_author(self):
+        self.check_talk_view(self.talk_r, False, False, auth={
+            'username': 'author_r', 'password': 'author_r_password',
+        })
+
+    def test_view_notes_accepted_has_view_all_perm(self):
+        create_user('reviewer', perms=['view_all_talks'])
+        self.check_talk_view(self.talk_a, True, False, auth={
+            'username': 'reviewer', 'password': 'reviewer_password',
+        })
+
+    def test_view_notes_rejected_has_view_all_perm(self):
+        create_user('reviewer', perms=['view_all_talks'])
+        self.check_talk_view(self.talk_r, True, False, auth={
+            'username': 'reviewer', 'password': 'reviewer_password',
+        })
+
+    def test_view_notes_accepted_has_edit_private_notes(self):
+        create_user('editor', perms=['edit_private_notes'])
+        self.check_talk_view(self.talk_a, False, True, auth={
+            'username': 'editor', 'password': 'editor_password',
+        })
+
+    def test_view_notes_rejected_has_edit_private_notes(self):
+        # edit_private_notes doesn't imply view_all_talks
+        create_user('editor', perms=['edit_private_notes'])
+        self.check_talk_view(self.talk_r, False, False, auth={
+            'username': 'editor', 'password': 'editor_password',
+        })
+
+    def test_view_notes_rejected_both_perms(self):
+        create_user('editor', perms=['edit_private_notes', 'view_all_talks'])
+        self.check_talk_view(self.talk_r, True, True, auth={
+            'username': 'editor', 'password': 'editor_password',
+        })
+
+
+    def test_view_notes_accepted_superuser(self):
+        create_user('super', superuser=True)
+        self.check_talk_view(self.talk_a, True, True, auth={
+            'username': 'super', 'password': 'super_password',
+        })
+
+    def test_view_notes_rejected_superuser(self):
+        create_user('super', superuser=True)
+        self.check_talk_view(self.talk_r, True, True, auth={
+            'username': 'super', 'password': 'super_password',
         })
 
 

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -155,13 +155,20 @@ class TalkNoteViewTests(TestCase):
         response = self.client.get(
             reverse('wafer_talk', kwargs={'pk': talk.pk}))
         if notes_visible:
-            self.assertTrue('Some notes for talk' in str(response))
+            self.assertTrue('Some notes for talk' in response.rendered_content)
         else:
-            self.assertFalse('Some notes for talk' in str(response))
+            # If the response doesn't have a rendered_content
+            # (HttpResponseForbidden, etc), this is trivially true,
+            # so we don't bother to test it.
+            if hasattr(response, 'rendered_content'):
+                self.assertFalse('Some notes for talk' in
+                                 response.rendered_content)
         if private_notes_visible:
-            self.assertTrue('Some private notes for talk' in str(response))
+            self.assertTrue('Some private notes for talk' in response.rendered_content)
         else:
-            self.assertFalse('Some private notes for talk' in str(response))
+            if hasattr(response, 'rendered_content'):
+                self.assertFalse('Some private notes for talk' in
+                                 response.rendered_content)
 
     def test_view_notes_accepted_not_logged_in(self):
         self.check_talk_view(self.talk_a, False, False)


### PR DESCRIPTION
This handles displaying the talks notes on the talk view, and adds some tests for this.

It also includes some other cleanups related to talks and private notes.

Closes #170