### PR TITLE
Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ python:
    - "3.4"
    - "3.5"
 env:
-   - DJANGO_VERSION=1.8 TESTDB=sqlite
-   - DJANGO_VERSION=1.8 TESTDB=postgres
-   - DJANGO_VERSION=1.9 TESTDB=sqlite
-   - DJANGO_VERSION=1.9 TESTDB=postgres
-   - DJANGO_VERSION=1.10 TESTDB=sqlite
-   - DJANGO_VERSION=1.10 TESTDB=postgres
+   - DJANGO_VERSION=1.8.0 TESTDB=sqlite
+   - DJANGO_VERSION=1.8.0 TESTDB=postgres
+   - DJANGO_VERSION=1.9.0 TESTDB=sqlite
+   - DJANGO_VERSION=1.9.0 TESTDB=postgres
+   - DJANGO_VERSION=1.10.0 TESTDB=sqlite
+   - DJANGO_VERSION=1.10.0 TESTDB=postgres
    - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
    - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
@@ -19,13 +19,13 @@ matrix:
    exclude:
       # Django no longer supports 3.3
       - python: "3.3"
-        env: DJANGO_VERSION=1.9 TESTDB=sqlite
+        env: DJANGO_VERSION=1.9.0 TESTDB=sqlite
       - python: "3.3"
-        env: DJANGO_VERSION=1.9 TESTDB=postgres
+        env: DJANGO_VERSION=1.9.0 TESTDB=postgres
       - python: "3.3"
-        env: DJANGO_VERSION=1.10 TESTDB=sqlite
+        env: DJANGO_VERSION=1.10.0 TESTDB=sqlite
       - python: "3.3"
-        env: DJANGO_VERSION=1.10 TESTDB=postgres
+        env: DJANGO_VERSION=1.10.0 TESTDB=postgres
       - python: "3.3"
         env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
       - python: "3.3"
@@ -42,7 +42,7 @@ before_install:
 # command to install dependencies,
 install:
    # Install the right version of Django first
-   - pip install 'Django~='"$DJANGO_VERSION".0
+   - pip install 'Django~='"$DJANGO_VERSION"
    - pip install -r requirements.txt -r requirements-dev.txt
 # command to run tests
 script: NOSE_WITH_COVERAGE=1 python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ allow_failures:
 
 services:
    - postgresql
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 before_install:
    - if [ "$TESTDB" = "postgres" ]; then pip install -q psycopg2 ; fi
 # command to install dependencies,

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,31 @@ env:
    - DJANGO_VERSION=1.8 TESTDB=postgres
    - DJANGO_VERSION=1.9 TESTDB=sqlite
    - DJANGO_VERSION=1.9 TESTDB=postgres
+   - DJANGO_VERSION=1.10 TESTDB=sqlite
+   - DJANGO_VERSION=1.10 TESTDB=postgres
+   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
+
 matrix:
    exclude:
-      # Django 1.9 doesn't support 3.3
+      # Django no longer supports 3.3
       - python: "3.3"
         env: DJANGO_VERSION=1.9 TESTDB=sqlite
       - python: "3.3"
         env: DJANGO_VERSION=1.9 TESTDB=postgres
+      - python: "3.3"
+        env: DJANGO_VERSION=1.10 TESTDB=sqlite
+      - python: "3.3"
+        env: DJANGO_VERSION=1.10 TESTDB=postgres
+      - python: "3.3"
+        env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+      - python: "3.3"
+        env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
+
+allow_failures:
+  - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
+  - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+
 services:
    - postgresql
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,34 +6,31 @@ python:
    - "3.4"
    - "3.5"
 env:
-   - DJANGO_VERSION=1.8.0 TESTDB=sqlite
-   - DJANGO_VERSION=1.8.0 TESTDB=postgres
-   - DJANGO_VERSION=1.9.0 TESTDB=sqlite
-   - DJANGO_VERSION=1.9.0 TESTDB=postgres
-   - DJANGO_VERSION=1.10.0 TESTDB=sqlite
-   - DJANGO_VERSION=1.10.0 TESTDB=postgres
-   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
-   - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
+   - DJANGO='django>=1.8.0,<1.9.0' TESTDB=sqlite
+   - DJANGO='django>=1.8.0,<1.9.0' TESTDB=postgres
+   - DJANGO='django>=1.9.0,<1.10.0' TESTDB=sqlite
+   - DJANGO='django>=1.9.0,<1.10.0' TESTDB=postgres
+   - DJANGO='django>=1.10.0,<1.11.0' TESTDB=sqlite
+   - DJANGO='django>=1.10.0,<1.11.0' TESTDB=postgres
+   - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+   - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
 matrix:
    exclude:
       # Django no longer supports 3.3
       - python: "3.3"
-        env: DJANGO_VERSION=1.9.0 TESTDB=sqlite
+        env: DJANGO='django>=1.9.0,<1.10.0' TESTDB=sqlite
       - python: "3.3"
-        env: DJANGO_VERSION=1.9.0 TESTDB=postgres
+        env: DJANGO='django>=1.9.0,<1.10.0' TESTDB=postgres
       - python: "3.3"
-        env: DJANGO_VERSION=1.10.0 TESTDB=sqlite
+        env: DJANGO='django>=1.10.0,<1.11.0' TESTDB=sqlite
       - python: "3.3"
-        env: DJANGO_VERSION=1.10.0 TESTDB=postgres
+        env: DJANGO='django>=1.10.0,<1.11.0' TESTDB=postgres
       - python: "3.3"
-        env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
-      - python: "3.3"
-        env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
 allow_failures:
-  - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
-  - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+  - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
+  - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
 
 services:
    - postgresql
@@ -42,7 +39,7 @@ before_install:
 # command to install dependencies,
 install:
    # Install the right version of Django first
-   - pip install 'Django~='"$DJANGO_VERSION"
+   - pip install $DJANGO
    - pip install -r requirements.txt -r requirements-dev.txt
 # command to run tests
 script: NOSE_WITH_COVERAGE=1 python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 # command to install dependencies,
 install:
    # Install the right version of Django first
-   - pip install $DJANGO
+   - pip install "$DJANGO"
    - pip install -r requirements.txt -r requirements-dev.txt
 # command to run tests
 script: NOSE_WITH_COVERAGE=1 python manage.py test

--- a/wafer/kv/urls.py
+++ b/wafer/kv/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import include, url
 
 from rest_framework import routers
 
@@ -7,7 +7,6 @@ from wafer.kv.views import KeyValueViewSet
 router = routers.DefaultRouter()
 router.register(r'kv', KeyValueViewSet)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^api/', include(router.urls)),
-)
+]

--- a/wafer/pages/urls.py
+++ b/wafer/pages/urls.py
@@ -1,13 +1,16 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import include, url
+from django.core.urlresolvers import get_script_prefix
+from django.views.generic import RedirectView
 from rest_framework import routers
 
-from wafer.pages.views import PageViewSet
+from wafer.pages.views import PageViewSet, slug
 
 router = routers.DefaultRouter()
 router.register(r'pages', PageViewSet)
 
-urlpatterns = patterns(
-    'wafer.pages.views',
+urlpatterns = [
     url(r'^api/', include(router.urls)),
-    url(r'^(?:(.+)/)?$', 'slug', name='wafer_page'),
-)
+    url('^index(?:\.html)?/?$', RedirectView.as_view(
+        url=get_script_prefix(), permanent=True, query_string=True)),
+    url(r'^(?:(.+)/)?$', slug, name='wafer_page'),
+]

--- a/wafer/registration/forms.py
+++ b/wafer/registration/forms.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
@@ -14,7 +15,7 @@ class RegistrationFormHelper(FormHelper):
 
 
 class LoginFormHelper(FormHelper):
-    form_action = reverse('django.contrib.auth.views.login')
+    form_action = settings.LOGIN_URL
 
     def __init__(self, *args, **kwargs):
         super(LoginFormHelper, self).__init__(*args, **kwargs)

--- a/wafer/registration/urls.py
+++ b/wafer/registration/urls.py
@@ -1,14 +1,16 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.views.generic import TemplateView
+
 from registration.backends.default.views import ActivationView, RegistrationView
 
+from wafer.registration.views import debian_login, github_login, redirect_profile
 
-urlpatterns = patterns(
-    'wafer.registration.views',
-    url(r'^profile/$', 'redirect_profile'),
 
-    url(r'^github-login/$', 'github_login'),
-    url(r'^debian-login/$', 'debian_login'),
+urlpatterns = [
+    url(r'^profile/$', redirect_profile),
+
+    url(r'^github-login/$', github_login),
+    url(r'^debian-login/$', debian_login),
 
     # registration.backends.default.urls, but Django 1.5 compatible
     url(r'^activate/complete/$',
@@ -33,4 +35,4 @@ urlpatterns = patterns(
             template_name='registration/registration_closed.html'
         ), name='registration_disallowed'),
     url(r'', include('registration.auth_urls')),
-)
+]

--- a/wafer/schedule/urls.py
+++ b/wafer/schedule/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from rest_framework import routers
 
 
@@ -8,12 +8,11 @@ from wafer.schedule.views import (
 router = routers.DefaultRouter()
 router.register(r'scheduleitems', ScheduleItemViewSet)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', ScheduleView.as_view(), name='wafer_full_schedule'),
     url(r'^venue/(?P<pk>\d+)/$', VenueView.as_view(), name='wafer_venue'),
     url(r'^current/$', CurrentView.as_view(), name='wafer_current'),
     url(r'^pentabarf\.xml$', ScheduleXmlView.as_view(),
         name='wafer_pentabarf_xml'),
     url(r'^api/', include(router.urls)),
-)
+]

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -93,12 +93,33 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '8iysa30^no&oi5kv$k1w)#gsxzrylr-h6%)loz71expnbf7z%)'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
-)
+TEMPLATES = [
+    {
+        'APP_DIRS': True,
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': (
+            # Put strings here, like "/home/html/django_templates" or
+            # "C:/www/django/templates". Always use forward slashes, even on Windows.
+            # Don't forget to use absolute paths, not relative paths.
+        ),
+        'OPTIONS': {
+            'context_processors': (
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'wafer.context_processors.site_info',
+                'wafer.context_processors.navigation_info',
+                'wafer.context_processors.menu_info',
+                'wafer.context_processors.registration_settings'
+            )
+        }
+    },
+]
+
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -116,25 +137,6 @@ ROOT_URLCONF = 'wafer.urls'
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'wafer.wsgi.application'
 
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or
-    # "C:/www/django/templates". Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.tz',
-    'django.contrib.messages.context_processors.messages',
-    'wafer.context_processors.site_info',
-    'wafer.context_processors.navigation_info',
-    'wafer.context_processors.menu_info',
-    'wafer.context_processors.registration_settings',
-)
 
 INSTALLED_APPS = (
     'django.contrib.auth',

--- a/wafer/sponsors/urls.py
+++ b/wafer/sponsors/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from rest_framework import routers
 
 from wafer.sponsors.views import (
@@ -9,12 +9,11 @@ router = routers.DefaultRouter()
 router.register(r'sponsors', SponsorViewSet)
 router.register(r'packages', PackageViewSet)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', ShowSponsors.as_view(),
         name='wafer_sponsors'),
     url(r'^(?P<pk>\d+)/$', SponsorView.as_view(), name='wafer_sponsor'),
     url(r'^packages/$', ShowPackages.as_view(),
         name='wafer_sponsorship_packages'),
     url(r'^api/', include(router.urls)),
-)
+]

--- a/wafer/talks/urls.py
+++ b/wafer/talks/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_extensions import routers
 
 from wafer.talks.views import (
     Speakers, TalkCreate, TalkDelete, TalkUpdate, TalkView, UsersTalks,

--- a/wafer/talks/urls.py
+++ b/wafer/talks/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import patterns, url, include
-from rest_framework_extensions import routers
+from django.conf.urls import url, include
+from rest_framework import routers
 
 from wafer.talks.views import (
     Speakers, TalkCreate, TalkDelete, TalkUpdate, TalkView, UsersTalks,
@@ -12,8 +12,7 @@ talks_router.register(
     r'urls', TalkUrlsViewSet, base_name='talks-urls',
     parents_query_lookups=['talk'])
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', UsersTalks.as_view(), name='wafer_users_talks'),
     url(r'^page/(?P<page>\d+)/$', UsersTalks.as_view(),
         name='wafer_users_talks_page'),
@@ -25,4 +24,4 @@ urlpatterns = patterns(
         name='wafer_talk_delete'),
     url(r'^speakers/$', Speakers.as_view(), name='wafer_talks_speakers'),
     url(r'^api/', include(router.urls)),
-)
+]

--- a/wafer/tickets/urls.py
+++ b/wafer/tickets/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, url
-from wafer.tickets.views import ClaimView
+from django.conf.urls import url
+from wafer.tickets.views import ClaimView, zapier_cancel_hook, zapier_guest_hook
 
 
-urlpatterns = patterns(
-    'wafer.tickets.views',
+urlpatterns = [
     url(r'^claim/$', ClaimView.as_view(), name='wafer_ticket_claim'),
-    url(r'^zapier_guest_hook/$', 'zapier_guest_hook'),
-    url(r'^zapier_cancel_hook/$', 'zapier_cancel_hook'),
-)
+    url(r'^zapier_guest_hook/$', zapier_guest_hook),
+    url(r'^zapier_cancel_hook/$', zapier_cancel_hook),
+]
+

--- a/wafer/urls.py
+++ b/wafer/urls.py
@@ -6,16 +6,16 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = [
-    (r'^accounts/', include('wafer.registration.urls')),
-    (r'^users/', include('wafer.users.urls')),
-    (r'^talks/', include('wafer.talks.urls')),
-    (r'^sponsors/', include('wafer.sponsors.urls')),
-    (r'^pages/', include('wafer.pages.urls')),
-    (r'^admin/', include(admin.site.urls)),
-    (r'^markitup/', include('markitup.urls')),
-    (r'^schedule/', include('wafer.schedule.urls')),
-    (r'^tickets/', include('wafer.tickets.urls')),
-    (r'^kv/', include('wafer.kv.urls')),
+    url(r'^accounts/', include('wafer.registration.urls')),
+    url(r'^users/', include('wafer.users.urls')),
+    url(r'^talks/', include('wafer.talks.urls')),
+    url(r'^sponsors/', include('wafer.sponsors.urls')),
+    url(r'^pages/', include('wafer.pages.urls')),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^markitup/', include('markitup.urls')),
+    url(r'^schedule/', include('wafer.schedule.urls')),
+    url(r'^tickets/', include('wafer.tickets.urls')),
+    url(r'^kv/', include('wafer.kv.urls')),
 ]
 
 # Serve media

--- a/wafer/urls.py
+++ b/wafer/urls.py
@@ -1,13 +1,11 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.conf import settings
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     (r'^accounts/', include('wafer.registration.urls')),
     (r'^users/', include('wafer.users.urls')),
     (r'^talks/', include('wafer.talks.urls')),
@@ -18,7 +16,7 @@ urlpatterns = patterns(
     (r'^schedule/', include('wafer.schedule.urls')),
     (r'^tickets/', include('wafer.tickets.urls')),
     (r'^kv/', include('wafer.kv.urls')),
-)
+]
 
 # Serve media
 if settings.DEBUG:

--- a/wafer/users/urls.py
+++ b/wafer/users/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import include, url
 from rest_framework import routers
 
 from wafer.users.views import (UsersView, ProfileView, EditProfileView,
@@ -8,8 +8,7 @@ from wafer.users.views import (UsersView, ProfileView, EditProfileView,
 router = routers.DefaultRouter()
 router.register(r'users', UserViewSet)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', UsersView.as_view(),
         name='wafer_users'),
     url(r'^api/', include(router.urls)),
@@ -25,4 +24,4 @@ urlpatterns = patterns(
     url(r'^(?P<username>[\w.@+-]+)/register/$',
         RegistrationView.as_view(),
         name='wafer_register_view'),
-)
+]


### PR DESCRIPTION
PR for tracking support for Django 1.10

- [x] `django.conf.urls.pattern` has been removed
- [x] checking namespace/app_name patterns stuff still works (I blindly deleted lines that might 
need to come back)
- [x] django rest framework issue:

```
Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x102796158>
  File "/src/git/ctpug/wafer/wafer/users/urls.py", line 14, in <module>
    url(r'^api/', include(router.urls)),
  File "/src/git/ctpug/wafer/virtualenv/lib/python3.5/site-packages/rest_framework/routers.py", line 79, in urls
    self._urls = self.get_urls()
  File "/src/git/ctpug/wafer/virtualenv/lib/python3.5/site-packages/rest_framework/routers.py", line 321, in get_urls
    urls = format_suffix_patterns(urls)
  File "/src/git/ctpug/wafer/virtualenv/lib/python3.5/site-packages/rest_framework/urlpatterns.py", line 64, in format_suffix_patterns
    return apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required)
  File "/src/git/ctpug/wafer/virtualenv/lib/python3.5/site-packages/rest_framework/urlpatterns.py", line 27, in apply_suffix_patterns
    view = urlpattern._callback or urlpattern._callback_str
AttributeError: 'RegexURLPattern' object has no attribute '_callback'
```