### PR TITLE
Add simple heading callouts to sponsors list page

### DIFF
--- a/wafer/sponsors/templates/wafer.sponsors/sponsors.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors.html
@@ -8,6 +8,9 @@
     <section class="wafer wafer-sponsor">
     <div class="well">
       <h2 class="bs-callout bs-callout-default bs-callout-{{ sponsor.packages.first.name.lower }}">
+         {% if sponsor.packages.first.name.lower == 'platinum' %}
+            ★
+         {% endif %}
          {% if sponsor.url %}
          <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>
          {% else %}

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors.html
@@ -6,16 +6,18 @@
 <div class="wafer list">
     {% for sponsor in sponsor_list %}
     <section class="wafer wafer-sponsor">
-    <div>
-        <h2>
-           {% if sponsor.url %}
-           <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>
-           {% else %}
-           {{ sponsor.name }}
-           {% endif %}
-        </h2>
-        {{ sponsor.description.rendered|safe }}
+    <div class="well">
+      <h2 class="bs-callout bs-callout-default bs-callout-{{ sponsor.packages.first.name.lower }}">
+         {% if sponsor.url %}
+         <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>
+         {% else %}
+         {{ sponsor.name }}
+         {% endif %}
+        <small class="text-right">{{ sponsor.packages.first.name }}</small>
+      </h2>
+      {{ sponsor.description.rendered|safe }}
     </div>
+    <hr>
     </section>
     {% empty %}
     <p>No sponsors yet.</p>

--- a/wafer/static/css/wafer.css
+++ b/wafer/static/css/wafer.css
@@ -39,3 +39,96 @@
 .droppable.over{
     border: 5px dashed #000;
 }
+
+.bs-callout {
+    padding: 5px;
+    margin: 20px 0;
+    border: 1px solid #eee;
+    border-left-width: 10px;
+    border-radius: 6px;
+}
+
+.bs-callout h4 {
+    margin-top: 0;
+    margin-bottom: 5px;
+}
+
+.bs-callout p:last-child {
+    margin-bottom: 0;
+}
+
+.bs-callout code {
+    border-radius: 3px;
+}
+
+.bs-callout+.bs-callout {
+    margin-top: -5px;
+}
+
+.bs-callout-default {
+    border-left-color: #777;
+}
+
+.bs-callout-default h4 {
+    color: #777;
+}
+
+.bs-callout-primary {
+    border-left-color: #428bca;
+}
+
+.bs-callout-primary h4 {
+    color: #428bca;
+}
+
+.bs-callout-success {
+    border-left-color: #5cb85c;
+}
+
+.bs-callout-success h4 {
+    color: #5cb85c;
+}
+
+.bs-callout-danger {
+    border-left-color: #d9534f;
+}
+
+.bs-callout-danger h4 {
+    color: #d9534f;
+}
+
+.bs-callout-warning {
+    border-left-color: #f0ad4e;
+}
+
+.bs-callout-warning h4 {
+    color: #f0ad4e;
+}
+
+.bs-callout-info {
+    border-left-color: #5bc0de;
+}
+
+.bs-callout-info h4 {
+    color: #5bc0de;
+}
+
+.bs-callout-platinum {
+    border-left-color: #E5E4E2;
+}
+
+.bs-callout-gold {
+    border-left-color: #DAA520;
+}
+
+.bs-callout-silver {
+    border-left-color: #C0C0C0;
+}
+
+.bs-callout-bronze {
+    border-left-color: #CD7F32;
+}
+
+.bs-callout-patron {
+    border-left-color: #A4C639;
+}


### PR DESCRIPTION
To make sponsor packages more obvious.

I think I need to drop or use smaller wells, since it doesn't look great with default bootstrap.



## Default Bootstrap Theme

[Before](https://cloud.githubusercontent.com/assets/2572493/16745028/563fa572-47b4-11e6-9bc0-d5bafd1153d5.png)

[After](https://cloud.githubusercontent.com/assets/2572493/16745039/6251b08a-47b4-11e6-9b1d-e0352252d085.png)

## PyConZA Theme

(I dropped the body background colour for PyConZA's CSS to make Platinum look a bit better)

[Before](https://cloud.githubusercontent.com/assets/2572493/16745045/6df1c984-47b4-11e6-8c6c-d48d9bf45804.png)

[After](https://cloud.githubusercontent.com/assets/2572493/16745071/8394ddbc-47b4-11e6-8a48-8d64fae96507.png)


## Still to do:

- [ ] Better alignment of the actual name of the package, or dropping it, and letting platinums have stars.
- [ ] Fix well padding