### PR TITLE
Add edit button to talk list in the profile

### DIFF
--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -110,10 +110,12 @@
 {% for talk in profile.pending_talks %}
 <div class="well">
     <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
-    <!-- Because this is one of the author's pending talks, we don't need to
-         check for edit permission's on the talk explictly. This doesn't show
-         the edit button for people with 'change-talk' permissions, but we
-         accept that tradeoff for simplicity here. -->
+    {% comment %}
+    Because this is one of the author's pending talks, we don't need to
+    check for edit permission's on the talk explictly. This doesn't show
+    the edit button for people with 'change-talk' permissions, but we
+    accept that tradeoff for simplicity here.
+    {% endcomment %}
     <a href="{% url 'wafer_talk_edit' talk.pk %}" class="pull-right btn btn-default btn-lg">{% trans 'Edit' %}</a>
     <p>{{ talk.abstract.rendered|safe }}</p>
 </div>

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -110,6 +110,11 @@
 {% for talk in profile.pending_talks %}
 <div class="well">
     <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
+    <!-- Because this is one of the author's pending talks, we don't need to
+         check for edit permission's on the talk explictly. This doesn't show
+         the edit button for people with 'change-talk' permissions, but we
+         accept that tradeoff for simplicity here. -->
+    <a href="{% url 'wafer_talk_edit' talk.pk %}" class="pull-right btn btn-default btn-lg">{% trans 'Edit' %}</a>
     <p>{{ talk.abstract.rendered|safe }}</p>
 </div>
 {% endfor %}


### PR DESCRIPTION
In an effort to make talk editing more obvious and close #279 , this adds edit buttons to the pending talks list in the user profile.