### PR TITLE
Features/issue 251 disable specific talk types

### DIFF
--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -60,7 +60,7 @@ class TalkAdmin(CompareVersionAdmin, admin.ModelAdmin):
 
 
 class TalkTypeAdmin(VersionAdmin, admin.ModelAdmin):
-    list_display = ('name', 'css_class')
+    list_display = ('name', 'order', 'disable_submission', 'css_class')
     readonly_fields = ('css_class',)
 
 

--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -2,6 +2,7 @@ import copy
 
 from django import forms
 from django.conf import settings
+from django.db.models import Q
 from django.core.urlresolvers import reverse
 from django.utils.module_loading import import_string
 from django.utils.translation import ugettext as _
@@ -12,7 +13,7 @@ from crispy_forms.layout import Submit, HTML
 from markitup.widgets import MarkItUpWidget
 from easy_select2.widgets import Select2Multiple
 
-from wafer.talks.models import Talk, render_author
+from wafer.talks.models import Talk, TalkType, render_author
 
 
 def get_talk_form_class():
@@ -55,6 +56,13 @@ class TalkForm(forms.ModelForm):
                             _('Delete')))))
         else:
             self.helper.add_input(submit_button)
+        # Exclude disabled talk types from the choice widget
+        if kwargs['instance']:
+            # Ensure the current talk type is in the query_set, regardless of whether it's been disabled since then
+            self.fields['talk_type'].queryset = TalkType.objects.filter(Q(disable_submission=False) | Q(pk=kwargs['instance'].talk_type.pk))
+        else:
+            self.fields['talk_type'].queryset = TalkType.objects.filter(disable_submission=False)
+
 
     class Meta:
         model = Talk

--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -57,7 +57,7 @@ class TalkForm(forms.ModelForm):
         else:
             self.helper.add_input(submit_button)
         # Exclude disabled talk types from the choice widget
-        if kwargs['instance']:
+        if kwargs['instance'] and kwargs['instance'].talk_type:
             # Ensure the current talk type is in the query_set, regardless of whether it's been disabled since then
             self.fields['talk_type'].queryset = TalkType.objects.filter(Q(disable_submission=False) | Q(pk=kwargs['instance'].talk_type.pk))
         else:

--- a/wafer/talks/migrations/0009_auto_20160813_1819.py
+++ b/wafer/talks/migrations/0009_auto_20160813_1819.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talks', '0008_auto_20160629_1404'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='talktype',
+            options={'ordering': ['order', 'id']},
+        ),
+        migrations.AddField(
+            model_name='talktype',
+            name='disable_submission',
+            field=models.BooleanField(default=False, help_text=b"Don't allow users to submit talks of this type."),
+        ),
+        migrations.AddField(
+            model_name='talktype',
+            name='order',
+            field=models.IntegerField(default=1),
+        ),
+    ]

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -26,12 +26,15 @@ class TalkType(models.Model):
     """A type of talk."""
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=1024)
+    order = models.IntegerField(default=1)
+    disable_submission = models.BooleanField(default=False,
+            help_text="Don't allow users to submit talks of this type.")
 
     def __str__(self):
         return u'%s' % (self.name,)
 
     class Meta:
-        ordering = ['id']
+        ordering = ['order', 'id']
 
     def css_class(self):
         """Return a string for use as a css class name"""

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -12,7 +12,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from wafer.utils import LoginRequiredMixin
-from wafer.talks.models import Talk, ACCEPTED
+from wafer.talks.models import Talk, TalkType, ACCEPTED
 from wafer.talks.forms import get_talk_form_class
 from wafer.talks.serializers import TalkSerializer
 from wafer.users.models import UserProfile
@@ -73,7 +73,11 @@ class TalkCreate(LoginRequiredMixin, CreateView):
 
     def get_context_data(self, **kwargs):
         context = super(TalkCreate, self).get_context_data(**kwargs)
-        context['can_submit'] = getattr(settings, 'WAFER_TALKS_OPEN', True)
+        can_submit = getattr(settings, 'WAFER_TALKS_OPEN', True)
+        if can_submit:
+            # Check for all talk types being disabled
+            can_submit = TalkType.objects.filter(disable_submission=False).count() > 0
+        context['can_submit'] = can_submit
         return context
 
     @revisions.create_revision()


### PR DESCRIPTION
To handle #251 , this adds a 'disable_submission' field to TalkType, so types can be managed individually.

I'm leaving the global enable / disable flag in place for now as that's more convienent than toggling each type.

Since I'm changing the TalkType model, I've also added an order field, since controlling the order talk types are presented to the user can be useful.