### PR TITLE
Feature/add comapre view for page editors

### DIFF
--- a/wafer/compare/admin.py
+++ b/wafer/compare/admin.py
@@ -47,6 +47,66 @@ class DateModifiedFilter(SimpleListFilter):
         return queryset.filter(pk__in=[x.object_id for x in revisions])
 
 
+
+def get_date(revision):
+    return revision.revision.date_created.strftime("%Y-%m-%d %H:%m:%S")
+
+
+def get_author(revision):
+    if revision.revision.user:
+        return revision.revision.user.username
+    return 'Unknown'
+
+
+def make_diff(current, revision):
+    """Create the difference between the current revision and a previous version"""
+    the_diff = []
+    dmp = diff_match_patch()
+
+    for field in (set(current.field_dict.keys()) | set(revision.field_dict.keys())):
+        # These exclusions really should be configurable
+        if field == 'id' or field.endswith('_rendered'):
+            continue
+        # KeyError's may happen if the database structure changes
+        # between the creation of revisions. This isn't ideal,
+        # but should not be a fatal error.
+        # Log this?
+        missing_field = False
+        try:
+            cur_val = current.field_dict[field] or ""
+        except KeyError:
+            cur_val = "No such field in latest version\n"
+            missing_field = True
+        try:
+            old_val = revision.field_dict[field] or ""
+        except KeyError:
+            old_val = "No such field in old version\n"
+            missing_field = True
+        if missing_field:
+            # Ensure that the complete texts are marked as changed
+            # so new entries containing any of the marker words
+            # don't show up as differences
+            diffs = [(dmp.DIFF_DELETE, old_val), (dmp.DIFF_INSERT, cur_val)]
+            patch =  dmp.diff_prettyHtml(diffs)
+        elif isinstance(cur_val, Markup):
+            # we roll our own diff here, so we can compare of the raw
+            # markdown, rather than the rendered result.
+            if cur_val.raw == old_val.raw:
+                continue
+            diffs = dmp.diff_main(old_val.raw, cur_val.raw)
+            patch =  dmp.diff_prettyHtml(diffs)
+        elif cur_val == old_val:
+            continue
+        else:
+            # Compare the actual field values
+            diffs = dmp.diff_main(force_text(old_val), force_text(cur_val))
+            patch = dmp.diff_prettyHtml(diffs)
+        the_diff.append((field, patch))
+
+    the_diff.sort()
+    return the_diff
+
+
 class CompareVersionAdmin(VersionAdmin):
 
     compare_template = "admin/wafer.compare/compare.html"
@@ -74,55 +134,14 @@ class CompareVersionAdmin(VersionAdmin):
         # The reversion we want to compare to
         current = Version.objects.get_for_object_reference(self.model, object_id)[0]
         revision = Version.objects.get_for_object_reference(self.model, object_id).filter(id=version_id)[0]
-        the_diff = []
-        dmp = diff_match_patch()
 
-        for field in (set(current.field_dict.keys()) | set(revision.field_dict.keys())):
-            # These exclusions really should be configurable
-            if field == 'id' or field.endswith('_rendered'):
-                continue
-            # KeyError's may happen if the database structure changes
-            # between the creation of revisions. This isn't ideal,
-            # but should not be a fatal error.
-            # Log this?
-            missing_field = False
-            try:
-                cur_val = current.field_dict[field] or ""
-            except KeyError:
-                cur_val = "No such field in latest version\n"
-                missing_field = True
-            try:
-                old_val = revision.field_dict[field] or ""
-            except KeyError:
-                old_val = "No such field in old version\n"
-                missing_field = True
-            if missing_field:
-                # Ensure that the complete texts are marked as changed
-                # so new entries containing any of the marker words
-                # don't show up as differences
-                diffs = [(dmp.DIFF_DELETE, old_val), (dmp.DIFF_INSERT, cur_val)]
-                patch =  dmp.diff_prettyHtml(diffs)
-            elif isinstance(cur_val, Markup):
-                # we roll our own diff here, so we can compare of the raw
-                # markdown, rather than the rendered result.
-                if cur_val.raw == old_val.raw:
-                    continue
-                diffs = dmp.diff_main(old_val.raw, cur_val.raw)
-                patch =  dmp.diff_prettyHtml(diffs)
-            elif cur_val == old_val:
-                continue
-            else:
-                # Compare the actual field values
-                diffs = dmp.diff_main(force_text(old_val), force_text(cur_val))
-                patch = dmp.diff_prettyHtml(diffs)
-            the_diff.append((field, patch))
-
-        the_diff.sort()
+        the_diff = make_diff(current, revision)
 
         context = {
             "title": _("Comparing current %(model)s with revision created %(date)s") % {
                 'model': current,
-                'date' : revision.revision.date_created.strftime("%Y-%m-%d %H:%m:%S")},
+                'date' : get_date(revision),
+                },
             "opts": opts,
             "compare_list_url": reverse("%s:%s_%s_comparelist" % (self.admin_site.name, opts.app_label, opts.model_name),
                                                                   args=(quote(object_id),)),

--- a/wafer/pages/templates/wafer.pages/page.html
+++ b/wafer/pages/templates/wafer.pages/page.html
@@ -4,6 +4,7 @@
 <div>
     {{ page.content.rendered|safe }}
     {% if perms.pages.change_page %}
+        <a href="{{ page.get_absolute_url }}?compare" class="pull-right btn btn-default btn-lg">{% trans 'Compare to Previous version' %}</a>
         <a href="{{ page.get_absolute_url }}?edit" class="pull-right btn btn-default btn-lg">{% trans 'Edit' %}</a>
     {% endif %}
 </div>

--- a/wafer/pages/templates/wafer.pages/page_compare.html
+++ b/wafer/pages/templates/wafer.pages/page_compare.html
@@ -1,0 +1,49 @@
+{% extends "wafer/base.html" %}
+
+{% load i18n %}
+{% block content %}
+
+<h1>Comparing Page</h1>
+
+{% if perms.pages.change_page %}
+
+   <p>Last Saved: {{ cur_date }} by {{ cur_author }}</p>
+
+   {% if prev_date %}
+      <p>Comparing to version saved: {{ prev_date }} by {{ prev_author }}</p>
+
+      <div>
+      {% for field, diff in diff_list %}
+      <section>
+         <h2 id="fieldname">{{ field }}</h2>
+         <div id="diff">
+            {{ diff | safe }}
+         </div>
+         {% empty %}
+         <div id="diff">
+            <p>{% trans 'No differences found' %}</p>
+         </div>
+      </section>
+      {% endfor %}
+      </div>
+
+      {# Add navigation buttons #}
+      <div>
+      {% if prev %}
+      <a href="{{ page.get_absolute_url }}?compare&version={{ prev }}" class="pull-left btn btn-default btn-lg">{% trans 'Compare to next older version' %}</a>
+      {% endif %}
+
+      {% if next %}
+      <a href="{{ page.get_absolute_url }}?compare&version={{ next }}" class="pull-right btn btn-default btn-lg">{% trans 'Compare to next newer version' %}</a>
+      {% endif %}
+      </div>
+
+   {% else %}
+      <p>No previous versions to compare to</p>
+   {% endif %}
+{% else %}
+   <p>Nothing to see here.</p>
+{% endif %}
+
+{% endblock %}
+

--- a/wafer/pages/templates/wafer.pages/page_compare.html
+++ b/wafer/pages/templates/wafer.pages/page_compare.html
@@ -30,11 +30,11 @@
       {# Add navigation buttons #}
       <div>
       {% if prev %}
-      <a href="{{ page.get_absolute_url }}?compare&version={{ prev }}" class="pull-left btn btn-default btn-lg">{% trans 'Compare to next older version' %}</a>
+      <a href="{{ page.get_absolute_url }}?compare&version={{ prev }}" class="btn btn-default btn-lg">{% trans 'Compare to next older version' %}</a>
       {% endif %}
-
+      <a href="{{ page.get_absolute_url }}" class="btn btn-success btn-lg">Return to Page</a>
       {% if next %}
-      <a href="{{ page.get_absolute_url }}?compare&version={{ next }}" class="pull-right btn btn-default btn-lg">{% trans 'Compare to next newer version' %}</a>
+      <a href="{{ page.get_absolute_url }}?compare&version={{ next }}" class="btn btn-default btn-lg">{% trans 'Compare to next newer version' %}</a>
       {% endif %}
       </div>
 

--- a/wafer/pages/templates/wafer.pages/page_compare.html
+++ b/wafer/pages/templates/wafer.pages/page_compare.html
@@ -5,12 +5,12 @@
 
 <h1>Comparing Page</h1>
 
-   <p>Last Saved: {{ cur_date }} by {{ cur_author }}</p>
+<p>Last Saved: {{ cur_date }} by {{ cur_author }}</p>
 
-   {% if prev_date %}
-      <p>Comparing to version saved: {{ prev_date }} by {{ prev_author }}</p>
+{% if prev_date %}
+   <p>Comparing to version saved: {{ prev_date }} by {{ prev_author }}</p>
 
-      <div>
+   <div>
       {% for field, diff in diff_list %}
       <section>
          <h2 id="fieldname">{{ field }}</h2>
@@ -23,10 +23,9 @@
          </div>
       </section>
       {% endfor %}
-      </div>
-
-      {# Add navigation buttons #}
-      <div>
+   </div>
+   {# Add navigation buttons #}
+   <div>
       {% if prev %}
       <a href="{{ page.get_absolute_url }}?compare&version={{ prev }}" class="btn btn-default btn-lg">{% trans 'Compare to next older version' %}</a>
       {% endif %}
@@ -34,11 +33,10 @@
       {% if next %}
       <a href="{{ page.get_absolute_url }}?compare&version={{ next }}" class="btn btn-default btn-lg">{% trans 'Compare to next newer version' %}</a>
       {% endif %}
-      </div>
-
-   {% else %}
-      <p>No previous versions to compare to</p>
-   {% endif %}
+   </div>
+{% else %}
+   <p>No previous versions to compare to</p>
+{% endif %}
 
 {% endblock %}
 

--- a/wafer/pages/templates/wafer.pages/page_compare.html
+++ b/wafer/pages/templates/wafer.pages/page_compare.html
@@ -5,8 +5,6 @@
 
 <h1>Comparing Page</h1>
 
-{% if perms.pages.change_page %}
-
    <p>Last Saved: {{ cur_date }} by {{ cur_author }}</p>
 
    {% if prev_date %}
@@ -41,9 +39,6 @@
    {% else %}
       <p>No previous versions to compare to</p>
    {% endif %}
-{% else %}
-   <p>Nothing to see here.</p>
-{% endif %}
 
 {% endblock %}
 

--- a/wafer/pages/views.py
+++ b/wafer/pages/views.py
@@ -3,8 +3,11 @@ from django.core.exceptions import PermissionDenied
 from django.views.generic import DetailView, TemplateView, UpdateView
 
 from reversion import revisions
+from reversion.models import Version
 from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+
+from wafer.compare.admin import make_diff, get_author, get_date
 
 from wafer.pages.models import Page
 from wafer.pages.serializers import PageSerializer
@@ -26,6 +29,51 @@ class EditPage(UpdateView):
         revisions.set_user(self.request.user)
         revisions.set_comment("Page Modified")
         return super(EditPage, self).form_valid(form)
+
+
+class ComparePage(DetailView):
+    template_name = 'wafer.pages/page_compare.html'
+    model = Page
+
+    def get_context_data(self, **kwargs):
+        context = super(ComparePage, self).get_context_data(**kwargs)
+
+        versions = Version.objects.get_for_object(self.object)
+        # By revisions api definition, this is the most recent version
+        current = versions[0]
+        context['cur_author'] = get_author(versions[0])
+        context['cur_date'] = get_date(versions[0])
+        context['prev_author'] = None
+        context['prev_date'] = None
+        context['prev'] = None
+        context['next'] = None
+        context['diff_list'] = None
+
+        if len(versions) == 1:
+            # only 1 version, so short circuit everything
+            return context
+        requested_version = int(self.request.GET.get('version', 1))
+        if requested_version > len(versions):
+            # Incorrect data, so fail to sane state
+            return context
+        if requested_version == 1:
+            # No next revision in this case
+            context['next'] = None
+        else:
+            context['next'] = requested_version - 1
+        if requested_version >= len(versions) - 1:
+            # No previous revision
+            context['prev'] = None
+        else:
+            context['prev'] = requested_version + 1
+
+        previous = versions[requested_version]
+        context['prev_author'] = get_author(previous)
+        context['prev_date'] = get_date(previous)
+
+        context['diff_list'] = make_diff(current, previous)
+
+        return context
 
 
 def slug(request, url):
@@ -51,6 +99,11 @@ def slug(request, url):
         if not request.user.has_perm('pages.change_page'):
             raise PermissionDenied
         return EditPage.as_view()(request, pk=page.id)
+
+    if 'compare' in request.GET:
+        if not request.user.has_perm('pages.change_page'):
+            raise PermissionDenied
+        return ComparePage.as_view()(request, pk=page.id)
 
     return ShowPage.as_view()(request, pk=page.id)
 


### PR DESCRIPTION
This adds a rough "compare" view for page editors, so they can examine changes without needing to go through the admin site.

It only compares past versions against the current version, which I think should cover most use cases.