### PR TITLE
Feature/speaker page links

### DIFF
--- a/wafer/talks/templates/wafer.talks/speakers.html
+++ b/wafer/talks/templates/wafer.talks/speakers.html
@@ -6,10 +6,14 @@
             <div class="row">
                 {% for user_profile in row %}
                     <div class="col-md-3">
+                      <a href="{% url 'wafer_user_profile' username=user_profile.user.username %}">
                         <img class="thumbnail center-block" src="{{ user_profile.avatar_url }}">
+                      </a>
+                      <a href="{% url 'wafer_user_profile' username=user_profile.user.username %}">
                         <h3 class="text-center">
                             {{ user_profile.display_name }}
                         </h3>
+                      </a>
                     </div>
                 {% endfor %}
             </div>

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -303,6 +303,7 @@ class SpeakerTests(TestCase):
     @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_view_one_speaker(self):
         img = self.talk_a.corresponding_author.userprofile.avatar_url()
+        username = self.talk_a.corresponding_author.username
         response = self.client.get(
             reverse('wafer_talks_speakers'))
         self.assertEqual(response.status_code, 200)
@@ -310,8 +311,12 @@ class SpeakerTests(TestCase):
             '<div class="container">',
             '<div class="row">',
             '    <div class="col-md-3">',
+            '      <a href="/users/%s/">' % username,
             '        <img class="thumbnail center-block" src="%s">' % img,
+            '      </a>',
+            '      <a href="/users/%s/">' % username,
             '        <h3 class="text-center">author_a</h3>',
+            '      </a>',
             '    </div>',
             '</div>',
             '</div>',

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -143,7 +143,7 @@ class Speakers(ListView):
     def get_context_data(self, **kwargs):
         context = super(Speakers, self).get_context_data(**kwargs)
         speakers = UserProfile.objects.filter(
-            user__talks__status='A').distinct().prefetch_related('user')
+            user__talks__status='A').distinct().prefetch_related('user').order_by('user__first_name', 'user__last_name')
         context["speaker_rows"] = self._by_row(speakers, 4)
         return context
 


### PR DESCRIPTION
This adds links from the speakers page view to the individual profiles, so it's easier to get to the information about individual speakers and their accepted talks.

This also sorts speakers by name, since the current ordering isn't particularly useful.