### PR TITLE
If django-registration's registration is disabled, block account creation via SSO

### DIFF
--- a/wafer/registration/sso.py
+++ b/wafer/registration/sso.py
@@ -27,6 +27,8 @@ def sso(user, desired_username, name, email, profile_fields=None):
     Then log the user in, and return it.
     """
     if not user:
+        if not settings.REGISTRATION_OPEN:
+            raise SSOError('Account registration is closed')
         user = _create_desired_user(desired_username)
         _configure_user(user, name, email, profile_fields)
 


### PR DESCRIPTION
For parity.