### PR TITLE
Be explicit

### DIFF
--- a/wafer/pages/urls.py
+++ b/wafer/pages/urls.py
@@ -12,6 +12,6 @@ urlpatterns = patterns(
     'wafer.pages.views',
     url(r'^api/', include(router.urls)),
     url('^index(?:\.html)?/?$', RedirectView.as_view(
-        url=get_script_prefix(), query_string=True)),
+        url=get_script_prefix(), permanent=True, query_string=True)),
     url(r'^(?:(.+)/)?$', 'slug', name='wafer_page'),
 )


### PR DESCRIPTION
To silence a deprecation warning, the default changes in 1.9.