### PR TITLE
Don't assume the additional count is always an integer

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -300,7 +300,7 @@ class SlotAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         super(SlotAdmin, self).save_model(request, obj, form, change)
-        if not change and form.cleaned_data['additional'] > 0:
+        if not change and form.cleaned_data['additional']:
             # We add the requested additional slots
             # All created slot will have the same length as the slot just
             # created , and we specify them as a sequence using


### PR DESCRIPTION
The additional count will be None if not entered, and is thus
unorderable on python 3. Since the validation will restrict
it to either None or the interval [0..20], the standard bool
comparison is actually all we need.

As seen recently on the pycon za site.