### PR TITLE
Add support for hiding navigation

### DIFF
--- a/wafer/context_processors.py
+++ b/wafer/context_processors.py
@@ -14,7 +14,7 @@ def site_info(request):
 
 
 def navigation_info(request):
-    '''Expose whether to display the navigation hear and footer'''
+    '''Expose whether to display the navigation header and footer'''
     if request.GET.get('wafer_hide_navigation') == "1":
         nav_class = "wafer-invisible"
     else:

--- a/wafer/context_processors.py
+++ b/wafer/context_processors.py
@@ -13,6 +13,18 @@ def site_info(request):
     return context
 
 
+def navigation_info(request):
+    '''Expose whether to display the navigation hear and footer'''
+    if request.GET.get('wafer_hide_navigation') == "1":
+        nav_class = "wafer-invisible"
+    else:
+        nav_class = "wafer-visible"
+    context = {
+        'WAFER_NAVIGATION_VISIBILITY': nav_class,
+    }
+    return context
+
+
 def menu_info(request):
     '''Expose the menus to templates'''
     menus = get_cached_menus()

--- a/wafer/static/css/wafer.css
+++ b/wafer/static/css/wafer.css
@@ -15,6 +15,13 @@
 	display: none;
 }
 
+#wafer-visible {
+}
+
+#wafer-invisible {
+	display: none;
+}
+
 .profile-links li{
 	list-style: none;
 	display: inline-block;

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="navbar navbar-inverse navbar-static-top">
+<div class="navbar navbar-inverse navbar-static-top {{ WAFER_NAVIGATION_VISIBILITY }}">
   <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#wafer-navbar-collapse">


### PR DESCRIPTION
The intention is to allow adding `?wafer_hide_navigation=1` to a `GET` URL to hide the navigation for use when displaying, e.g. the scheduled for a day or the next-up events, on a display at a conference.