### PR TITLE
Feature/include rendered abstract in pentabarf

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -39,14 +39,18 @@
                     {# It's not clear what the difference between abstract and description is meant to be #}
                     {# Both confclerk and Giggity just lump them together into the same thing anyway, and #}
                     {# summit only outputs stuff in description, so we keep abstract blank and follow #}
-                    {# summit's pattern and obly include stuff in the description #}
+                    {# summit's pattern and only include stuff in the description #}
                     <abstract/>
                     {% if items.item.talk %}
                        <title>{{ items.item.get_title }}</title>
                        {# I'm not sure if the raw markdown is the best thing here, but it seems to match what summit does, #}
                        {# so hopefully the tools can handle the odd corner cases correctly. Giggity at least does some #}
                        {# santization here. #}
-                       {% if items.item.talk.abstract %}
+                       {# We do allow people to request html if they want it, which may also be a bad idea, but is useful for #}
+                       {# the video team #}
+                       {% if items.item.talk.abstract and render_description %}
+                       <description>{{ items.item.talk.abstract.rendered }}</description>
+                       {% elif items.item.talk.abstract %}
                        <description>{{ items.item.talk.abstract.raw }}</description>
                        {% else %}
                        <description/>

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -143,8 +143,7 @@ class ScheduleXmlView(ScheduleView):
     def get_context_data(self, **kwargs):
         """Allow adding a 'render_description' parameter"""
         context = super(ScheduleXmlView, self).get_context_data(**kwargs)
-        render_description = self.request.GET.get('render_description', None)
-        if render_description in ['y', 'Y']:
+        if self.request.GET.get('render_description', None) == '1':
             context['render_description'] = True
         else:
             context['render_description'] = False

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -140,6 +140,16 @@ class ScheduleXmlView(ScheduleView):
     template_name = 'wafer.schedule/penta_schedule.xml'
     content_type = 'application/xml'
 
+    def get_context_data(self, **kwargs):
+        """Allow adding a 'render_description' parameter"""
+        context = super(ScheduleXmlView, self).get_context_data(**kwargs)
+        render_description = self.request.GET.get('render_description', None)
+        if render_description in ['y', 'Y']:
+            context['render_description'] = True
+        else:
+            context['render_description'] = False
+        return context
+
 
 class CurrentView(TemplateView):
     template_name = 'wafer.schedule/current.html'


### PR DESCRIPTION
There are almost certainly ways to break including , but they also exist in using the raw markdown, and this is useful for some comsumers of the pentabarf 