### PR TITLE
Pages content should also be html when render_description is passed to pentabarf view

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -78,7 +78,12 @@
                         {% if items.item.page.people.exists %}
                         {# If there are people, we care about the description #}
                         {# For now, we drop the raw markdown content from pages here. We probably want to sanatize this in the future #}
+                        {# Also honour render_description #}
+                        {% if render_description %}
+                        <description>{{ items.item.page.content.rendered }}</description>
+                        {% else %}
                         <description>{{ items.item.page.content.raw }}</description>
+                        {% endif %}
                         <persons>
                            {# TODO: This should be refactored, so we don't have all this duplication #}
                            {% for person in items.item.page.people.all %}


### PR DESCRIPTION
Since mixing markdown and html output is not what we want.