### PR TITLE
Add API endpoints for adding, removing and updating talk URLs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ REQUIRES = [
     'django-nose',
     'django-registration-redux',
     'djangorestframework',
+    'drf-extensions',
     'jsonfield',
     'pillow',
     'diff-match-patch',

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -16,6 +16,7 @@ PENDING = 'P'
 REJECTED = 'R'
 CANCELLED = 'C'
 
+
 # Utility functions used in the forms
 def render_author(author):
     return '%s (%s)' % (author.userprofile.display_name(), author)
@@ -27,8 +28,9 @@ class TalkType(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=1024)
     order = models.IntegerField(default=1)
-    disable_submission = models.BooleanField(default=False,
-            help_text="Don't allow users to submit talks of this type.")
+    disable_submission = models.BooleanField(
+        default=False,
+        help_text="Don't allow users to submit talks of this type.")
 
     def __str__(self):
         return u'%s' % (self.name,)

--- a/wafer/talks/serializers.py
+++ b/wafer/talks/serializers.py
@@ -17,13 +17,19 @@ class TalkUrlSerializer(serializers.ModelSerializer):
         read_only_fields = ('id',)
 
 
+class MarkdownSerializer(serializers.CharField):
+    def get_attribute(self, instance):
+        value = super(MarkdownSerializer, self).get_attribute(instance)
+        return value.raw
+
+
 class TalkSerializer(serializers.ModelSerializer):
 
     authors = serializers.PrimaryKeyRelatedField(
         many=True, allow_null=True,
         queryset=get_user_model().objects.all())
 
-    abstract = serializers.CharField(source='abstract.raw')
+    abstract = MarkdownSerializer()
 
     urls = TalkUrlSerializer(source='talkurl_set', many=True, read_only=True)
 
@@ -48,7 +54,4 @@ class TalkSerializer(serializers.ModelSerializer):
     @revisions.create_revision()
     def update(self, talk, validated_data):
         revisions.set_comment("Changed via REST api")
-        if 'abstract' in validated_data:
-            abstract = validated_data.pop('abstract')
-            talk.abstract = abstract['raw']
         return super(TalkSerializer, self).update(talk, validated_data)

--- a/wafer/talks/serializers.py
+++ b/wafer/talks/serializers.py
@@ -21,7 +21,6 @@ class TalkSerializer(serializers.ModelSerializer):
         # not be generally accessible
         exclude = ('_abstract_rendered', 'private_notes', 'notes')
 
-
     @revisions.create_revision()
     def create(self, validated_data):
         revisions.set_comment("Created via REST api")
@@ -36,7 +35,7 @@ class TalkSerializer(serializers.ModelSerializer):
         talk.authors = validated_data['authors']
         talk.status = validated_data['status']
         # These need more thought
-        #talk.notes = validated_data['notes']
-        #talk.private_notes = validated_data['private_notes']
+        # talk.notes = validated_data['notes']
+        # talk.private_notes = validated_data['private_notes']
         talk.save()
         return talk

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -482,7 +482,6 @@ class TalkViewSetTests(TestCase):
         talk_a = create_talk("Talk A", ACCEPTED, "author_a")
         talk_b = create_talk("Talk B", REJECTED, "author_b")
         response = self.client.get('/talks/api/talks/')
-        result_0, result_1 = response.data['results']
         self.assertEqual(response.data['results'], [
             self.mk_result(talk_a), self.mk_result(talk_b),
         ])
@@ -607,7 +606,6 @@ class TalkUrlsViewSetTests(TestCase):
         url_b = TalkUrl.objects.create(
             talk=talk, url="http://b.example.com/", description="slides")
         response = self.client.get('/talks/api/talks/%d/urls/' % talk.talk_id)
-        result_0, result_1 = response.data['results']
         self.assertEqual(response.data['results'], [
             self.mk_result(url_a), self.mk_result(url_b),
         ])

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -1,5 +1,7 @@
 """Tests for wafer.talk views."""
 
+import json
+
 import mock
 
 from django.contrib.auth import get_user_model
@@ -498,7 +500,6 @@ class TalkViewSetTests(TestCase):
 
     def test_create_talk(self):
         author = create_user("author")
-        import json
         response = self.client.post('/talks/api/talks/', data=json.dumps({
             'talk_type': None, 'status': 'A', 'title': 'Talk Foo',
             'abstract': 'Concrete',
@@ -509,10 +510,27 @@ class TalkViewSetTests(TestCase):
         self.assertEqual(response.data, self.mk_result(talk))
 
     def test_update_talk(self):
-        pass
+        talk = create_talk("Talk A", ACCEPTED, "author_a")
+        response = self.client.put(
+            '/talks/api/talks/%d/' % talk.talk_id, data=json.dumps({
+                'talk_type': None, 'status': 'R', 'title': 'Talk Zoom',
+                'abstract': 'Concreter',
+                'corresponding_author': talk.corresponding_author.id,
+                'authors': [talk.corresponding_author.id],
+            }), content_type="application/json")
+        talk = Talk.objects.get()
+        self.assertEqual(response.data, self.mk_result(talk))
+        self.assertEqual(talk.abstract.raw, u"Concreter")
 
     def test_patch_talk(self):
-        pass
+        talk = create_talk("Talk A", ACCEPTED, "author_a")
+        response = self.client.patch(
+            '/talks/api/talks/%d/' % talk.talk_id, data=json.dumps({
+                'abstract': 'Concrete',
+            }), content_type="application/json")
+        talk = Talk.objects.get()
+        self.assertEqual(response.data, self.mk_result(talk))
+        self.assertEqual(talk.abstract.raw, u"Concrete")
 
 
 class TalkUrlsViewSetPermissionTests(TestCase):

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -354,13 +354,27 @@ class SpeakerTests(TestCase):
         self.check_n_speakers(7, [(0, 4), (4, 7)])
 
 
+class SortedResultsClient(Client):
+    def _sorted_response(self, response):
+        def get_title(item):
+            print item
+            return item['title']
+        if 'results' in response.data:
+            response.data['results'].sort(key=get_title)
+        return response
+
+    def generic(self, *args, **kw):
+        response = super(SortedResultsClient, self).generic(*args, **kw)
+        return self._sorted_response(response)
+
+
 class TalkViewSetTests(TestCase):
 
     def setUp(self):
         self.talk_a = create_talk("Talk A", ACCEPTED, "author_a")
         self.talk_r = create_talk("Talk R", REJECTED, "author_r")
         self.talk_p = create_talk("Talk P", PENDING, "author_p")
-        self.client = Client()
+        self.client = SortedResultsClient()
 
     def test_unauthorized_users(self):
         response = self.client.get('/talks/api/talks/')
@@ -392,8 +406,8 @@ class TalkViewSetTests(TestCase):
         response = self.client.get('/talks/api/talks/')
         self.assertEqual(response.data['count'], 3)
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
-        self.assertEqual(response.data['results'][1]['title'], "Talk R")
-        self.assertEqual(response.data['results'][2]['title'], "Talk P")
+        self.assertEqual(response.data['results'][1]['title'], "Talk P")
+        self.assertEqual(response.data['results'][2]['title'], "Talk R")
         response = self.client.get(
             '/talks/api/talks/%d/' % self.talk_a.talk_id)
         self.assertEqual(response.data['title'], 'Talk A')
@@ -407,8 +421,8 @@ class TalkViewSetTests(TestCase):
         response = self.client.get('/talks/api/talks/')
         self.assertEqual(response.data['count'], 3)
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
-        self.assertEqual(response.data['results'][1]['title'], "Talk R")
-        self.assertEqual(response.data['results'][2]['title'], "Talk P")
+        self.assertEqual(response.data['results'][1]['title'], "Talk P")
+        self.assertEqual(response.data['results'][2]['title'], "Talk R")
         response = self.client.get(
             '/talks/api/talks/%d/' % self.talk_a.talk_id)
         self.assertEqual(response.data['title'], 'Talk A')
@@ -435,3 +449,7 @@ class TalkViewSetTests(TestCase):
         self.assertEqual(response.data['count'], 2)
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
         self.assertEqual(response.data['results'][1]['title'], "Talk P")
+
+
+class TalkUrlsViewSetTests(TestCase):
+    pass

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -6,7 +6,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
-from rest_framework.test import APIClient
+
+from wafer.tests.api_utils import SortedResultsClient
 from wafer.talks.models import (
     Talk, TalkUrl, ACCEPTED, REJECTED, PENDING, CANCELLED)
 
@@ -353,23 +354,6 @@ class SpeakerTests(TestCase):
     @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_view_seven_speakers(self):
         self.check_n_speakers(7, [(0, 4), (4, 7)])
-
-
-class SortedResultsClient(APIClient):
-    def __init__(self, *args, **kw):
-        self._sort_key = kw.pop('sort_key')
-        super(SortedResultsClient, self).__init__(*args, **kw)
-
-    def _sorted_response(self, response):
-        def get_key(item):
-            return item[self._sort_key]
-        if response.data and 'results' in response.data:
-            response.data['results'].sort(key=get_key)
-        return response
-
-    def generic(self, *args, **kw):
-        response = super(SortedResultsClient, self).generic(*args, **kw)
-        return self._sorted_response(response)
 
 
 class TalkViewSetPermissionTests(TestCase):

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -496,6 +496,24 @@ class TalkViewSetTests(TestCase):
             '/talks/api/talks/%d/' % talk.talk_id)
         self.assertEqual(response.data, self.mk_result(talk))
 
+    def test_create_talk(self):
+        author = create_user("author")
+        import json
+        response = self.client.post('/talks/api/talks/', data=json.dumps({
+            'talk_type': None, 'status': 'A', 'title': 'Talk Foo',
+            'abstract': 'Concrete',
+            'corresponding_author': author.id,
+            'authors': [author.id],
+        }), content_type="application/json")
+        talk = Talk.objects.get()
+        self.assertEqual(response.data, self.mk_result(talk))
+
+    def test_update_talk(self):
+        pass
+
+    def test_patch_talk(self):
+        pass
+
 
 class TalkUrlsViewSetPermissionTests(TestCase):
 

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -164,7 +164,8 @@ class TalkNoteViewTests(TestCase):
                 self.assertFalse('Some notes for talk' in
                                  response.rendered_content)
         if private_notes_visible:
-            self.assertTrue('Some private notes for talk' in response.rendered_content)
+            self.assertTrue(
+                'Some private notes for talk' in response.rendered_content)
         else:
             if hasattr(response, 'rendered_content'):
                 self.assertFalse('Some private notes for talk' in
@@ -355,7 +356,6 @@ class SpeakerTests(TestCase):
 
 class TalkViewSetTests(TestCase):
 
-
     def setUp(self):
         self.talk_a = create_talk("Talk A", ACCEPTED, "author_a")
         self.talk_r = create_talk("Talk R", REJECTED, "author_r")
@@ -366,9 +366,11 @@ class TalkViewSetTests(TestCase):
         response = self.client.get('/talks/api/talks/')
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_a.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_a.talk_id)
         self.assertEqual(response.data['title'], 'Talk A')
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_r.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_r.talk_id)
         self.assertEqual(response.status_code, 404)
 
     def test_ordinary_users_get_accepted_talks(self):
@@ -377,9 +379,11 @@ class TalkViewSetTests(TestCase):
         response = self.client.get('/talks/api/talks/')
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_a.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_a.talk_id)
         self.assertEqual(response.data['title'], 'Talk A')
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_r.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_r.talk_id)
         self.assertEqual(response.status_code, 404)
 
     def test_super_user_gets_everything(self):
@@ -390,9 +394,11 @@ class TalkViewSetTests(TestCase):
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
         self.assertEqual(response.data['results'][1]['title'], "Talk R")
         self.assertEqual(response.data['results'][2]['title'], "Talk P")
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_a.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_a.talk_id)
         self.assertEqual(response.data['title'], 'Talk A')
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_r.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_r.talk_id)
         self.assertEqual(response.data['title'], 'Talk R')
 
     def test_reviewer_all_talks(self):
@@ -403,9 +409,11 @@ class TalkViewSetTests(TestCase):
         self.assertEqual(response.data['results'][0]['title'], "Talk A")
         self.assertEqual(response.data['results'][1]['title'], "Talk R")
         self.assertEqual(response.data['results'][2]['title'], "Talk P")
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_a.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_a.talk_id)
         self.assertEqual(response.data['title'], 'Talk A')
-        response = self.client.get('/talks/api/talks/%d/' % self.talk_r.talk_id)
+        response = self.client.get(
+            '/talks/api/talks/%d/' % self.talk_r.talk_id)
         self.assertEqual(response.data['title'], 'Talk R')
 
     def test_author_a_sees_own_talks_only(self):

--- a/wafer/talks/urls.py
+++ b/wafer/talks/urls.py
@@ -1,12 +1,16 @@
 from django.conf.urls import patterns, url, include
-from rest_framework import routers
+from rest_framework_extensions import routers
 
 from wafer.talks.views import (
     Speakers, TalkCreate, TalkDelete, TalkUpdate, TalkView, UsersTalks,
-    TalksViewSet)
+    TalksViewSet, TalkUrlsViewSet)
 
-router = routers.DefaultRouter()
-router.register(r'talks', TalksViewSet)
+router = routers.ExtendedSimpleRouter()
+
+talks_router = router.register(r'talks', TalksViewSet)
+talks_router.register(
+    r'urls', TalkUrlsViewSet, base_name='talks-urls',
+    parents_query_lookups=['talk'])
 
 urlpatterns = patterns(
     '',

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -180,3 +180,11 @@ class TalkUrlsViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
     queryset = TalkUrl.objects.all()
     serializer_class = TalkUrlSerializer
     permission_classes = (DjangoModelPermissionsOrAnonReadOnly, )
+
+    def create(self, request, *args, **kw):
+        request.data['talk'] = self.get_parents_query_dict()['talk']
+        return super(TalkUrlsViewSet, self).create(request, *args, **kw)
+
+    def update(self, request, *args, **kw):
+        request.data['talk'] = self.get_parents_query_dict()['talk']
+        return super(TalkUrlsViewSet, self).update(request, *args, **kw)

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -76,7 +76,8 @@ class TalkCreate(LoginRequiredMixin, CreateView):
         can_submit = getattr(settings, 'WAFER_TALKS_OPEN', True)
         if can_submit:
             # Check for all talk types being disabled
-            can_submit = TalkType.objects.filter(disable_submission=False).count() > 0
+            can_submit = TalkType.objects.filter(
+                disable_submission=False).count() > 0
         context['can_submit'] = can_submit
         return context
 
@@ -143,7 +144,8 @@ class Speakers(ListView):
     def get_context_data(self, **kwargs):
         context = super(Speakers, self).get_context_data(**kwargs)
         speakers = UserProfile.objects.filter(
-            user__talks__status='A').distinct().prefetch_related('user').order_by('user__first_name', 'user__last_name')
+            user__talks__status='A').distinct().prefetch_related(
+                'user').order_by('user__first_name', 'user__last_name')
         context["speaker_rows"] = self._by_row(speakers, 4)
         return context
 
@@ -168,5 +170,5 @@ class TalksViewSet(viewsets.ModelViewSet):
             # XXX: Should this be all authors rather than just
             # the corresponding author?
             return Talk.objects.filter(
-                Q(status=ACCEPTED)|
+                Q(status=ACCEPTED) |
                 Q(corresponding_author=self.request.user))

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -10,11 +10,12 @@ from django.db.models import Q
 from reversion import revisions
 from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from wafer.utils import LoginRequiredMixin
-from wafer.talks.models import Talk, TalkType, ACCEPTED
+from wafer.talks.models import Talk, TalkType, TalkUrl, ACCEPTED
 from wafer.talks.forms import get_talk_form_class
-from wafer.talks.serializers import TalkSerializer
+from wafer.talks.serializers import TalkSerializer, TalkUrlSerializer
 from wafer.users.models import UserProfile
 
 
@@ -150,7 +151,7 @@ class Speakers(ListView):
         return context
 
 
-class TalksViewSet(viewsets.ModelViewSet):
+class TalksViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
     """API endpoint that allows talks to be viewed or edited."""
     queryset = Talk.objects.none()  # Needed for the REST Permissions
     serializer_class = TalkSerializer
@@ -172,3 +173,10 @@ class TalksViewSet(viewsets.ModelViewSet):
             return Talk.objects.filter(
                 Q(status=ACCEPTED) |
                 Q(corresponding_author=self.request.user))
+
+
+class TalkUrlsViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
+    """API endpoint that allows talks to be viewed or edited."""
+    queryset = TalkUrl.objects.all()
+    serializer_class = TalkUrlSerializer
+    permission_classes = (DjangoModelPermissionsOrAnonReadOnly, )

--- a/wafer/tests/api_utils.py
+++ b/wafer/tests/api_utils.py
@@ -1,0 +1,22 @@
+"""Utilities for testing wafer APIs."""
+
+from rest_framework.test import APIClient
+
+
+class SortedResultsClient(APIClient):
+    """ A client that sorts API results to make comparisons easier.
+    """
+    def __init__(self, *args, **kw):
+        self._sort_key = kw.pop('sort_key')
+        super(SortedResultsClient, self).__init__(*args, **kw)
+
+    def _sorted_response(self, response):
+        def get_key(item):
+            return item[self._sort_key]
+        if response.data and 'results' in response.data:
+            response.data['results'].sort(key=get_key)
+        return response
+
+    def generic(self, *args, **kw):
+        response = super(SortedResultsClient, self).generic(*args, **kw)
+        return self._sorted_response(response)


### PR DESCRIPTION
This adds the following API end points:

*  `/talks/api/talks/<talk_id>/urls/`
  * GET - list the URLs associated with a talk.
  * POST - add a URL to a talk.
*  `/talks/api/talks/<talk_id>/urls/<url_id>/`
  * GET - retrieve the URL
  * PUT - overwrite the URL
  * PATCH - update the URL
  * DELETE - delete the URL

If also adds a summary of the URLs to the data returned when querying the talks API.