### PR TITLE
Add catchall fields property to KeyValueSerializer

### DIFF
--- a/wafer/kv/serializers.py
+++ b/wafer/kv/serializers.py
@@ -7,6 +7,7 @@ class KeyValueSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = KeyValue
+        fields = ('group', 'key', 'value')
 
     # There doesn't seem to be a better way of handling the problem
     # of filtering the groups.


### PR DESCRIPTION
With the latest django-restframework, not explicitly setting the
fields for a serializer causes errors. This explicitly sets the
fields to those of the model.

This should fix the current build failures, and still work with any version of django-restframework >= 3.0.