### PR TITLE
Speakers page is missing from the static site, so add it

### DIFF
--- a/wafer/talks/renderers.py
+++ b/wafer/talks/renderers.py
@@ -19,6 +19,7 @@ class TalksRenderer(StaticSiteRenderer):
         for page in paginator.page_range:
             paths.append(reverse('wafer_users_talks_page',
                                  kwargs={'page': page}))
+        paths.append(reverse('wafer_talks_speakers'))
         return paths
 
 renderers = [TalksRenderer, ]


### PR DESCRIPTION
The speakers page isn't currently part of the pages generated for the static site, but it should be.