### PR TITLE
Feature/rework talk states

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.db.models import Q
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib import messages
@@ -8,7 +9,7 @@ from django.utils.translation import ugettext as _
 from django import forms
 
 from wafer.schedule.models import Day, Venue, Slot, ScheduleItem
-from wafer.talks.models import Talk, ACCEPTED
+from wafer.talks.models import Talk, ACCEPTED, CANCELLED
 from wafer.pages.models import Page
 from wafer.utils import cache_result
 
@@ -78,7 +79,7 @@ def validate_items(all_items=None):
             validation.append(item)
         elif item.talk is None and item.page is None:
             validation.append(item)
-        elif item.talk and item.talk.status != ACCEPTED:
+        elif item.talk and item.talk.status not in [ACCEPTED, CANCELLED]:
             validation.append(item)
     return validation
 
@@ -196,7 +197,8 @@ class ScheduleItemAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ScheduleItemAdminForm, self).__init__(*args, **kwargs)
-        self.fields['talk'].queryset = Talk.objects.filter(status=ACCEPTED)
+        self.fields['talk'].queryset = Talk.objects.filter(
+                Q(status=ACCEPTED) | Q(status=CANCELLED))
         # Present all pages as possible entries in the schedule
         self.fields['page'].queryset = Page.objects.all()
 

--- a/wafer/schedule/tests/test_admin.py
+++ b/wafer/schedule/tests/test_admin.py
@@ -10,7 +10,8 @@ from wafer.schedule.admin import (
     find_duplicate_schedule_items, find_clashes, find_invalid_venues,
     find_non_contiguous)
 from wafer.schedule.models import Day, Venue, Slot, ScheduleItem
-from wafer.talks.models import Talk, ACCEPTED, REJECTED, PENDING
+from wafer.talks.models import (Talk, ACCEPTED, REJECTED, CANCELLED,
+                                SUBMITTED, UNDER_CONSIDERATION)
 
 
 class DummyForm(object):
@@ -283,7 +284,17 @@ class ValidationTests(TestCase):
         invalid = validate_items()
         assert set(invalid) == set([item1, item2])
 
-        talk.status = PENDING
+        talk.status = SUBMITTED
+        talk.save()
+        invalid = validate_items()
+        assert set(invalid) == set([item1, item2])
+
+        talk.status = CANCELLED
+        talk.save()
+        invalid = validate_items()
+        assert set(invalid) == set([item1])
+
+        talk.status = UNDER_CONSIDERATION
         talk.save()
         invalid = validate_items()
         assert set(invalid) == set([item1, item2])

--- a/wafer/talks/migrations/0010_auto_20161121_2134.py
+++ b/wafer/talks/migrations/0010_auto_20161121_2134.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talks', '0009_auto_20160813_1819'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='talk',
+            name='status',
+            field=models.CharField(default=b'S', max_length=1, choices=[(b'A', b'Accepted'), (b'R', b'Not Accepted'), (b'C', b'Talk Cancelled'), (b'U', b'Under Consideration'), (b'S', b'Submitted'), (b'P', b'Provisionally Accepted')]),
+        ),
+    ]

--- a/wafer/talks/migrations/0011_talk_status_data_migration.py
+++ b/wafer/talks/migrations/0011_talk_status_data_migration.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+# Data migration for the changed talk status
+
+def change_pending(apps, schema_editor):
+    # Change Pending (P) status to
+    # (S) Submitted
+    # Use apps to ensure we have the correct version
+    Talk = apps.get_model("talks", "Talk")
+    for talk in Talk.objects.filter(status='P'):
+        talk.status = 'S'
+        talk.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talks', '0010_auto_20161121_2134'),
+    ]
+
+    operations = [
+            migrations.RunPython(change_pending),
+    ]

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -52,8 +52,12 @@
 <div>
     <p>
     {% trans 'Status:' %}
-    {% if object.pending %}
+    {% if object.submitted %}
+    <span class="tag tag-info">{% trans 'Submitted' %}</span>
+    {% elif object.under_consideration %}
     <span class="tag tag-info">{% trans 'Under consideration' %}</span>
+    {% elif object.provisional %}
+    <span class="tag tag-success">{% trans 'Provisionally Accepted' %}</span>
     {% elif object.accepted %}
     <span class="tag tag-success">{% trans 'Accepted' %}</span>
     {% elif object.cancelled %}

--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -6,12 +6,16 @@
 <div class="wafer list">
     {% for talk in talk_list %}
     <div>
-        {% if talk.pending %}
+        {% if talk.submitted %}
+        <span class="label label-info" title="{% trans 'Submitted' %}">{{ talk.status }}</span>
+        {% elif talk.under_consideration %}
         <span class="label label-info" title="{% trans 'Under consideration' %}">{{ talk.status }}</span>
         {% elif talk.reject %}
         <span class="label label-danger" title="{% trans 'Not accepted' %}">{{ talk.status }}</span>
         {% elif talk.cancelled %}
         <span class="label label-warning" title="{% trans 'Talk Cancelled' %}">{{ talk.status }}</span>
+        {% elif talk.provisional %}
+        <span class="label label-success" title="{% trans 'Provisionally Accepted' %}">{{ talk.status }}</span>
         {% endif %}
         <a class="page-link" href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
         by

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -20,7 +20,7 @@ from wafer.talks.models import (ACCEPTED, SUBMITTED, UNDER_CONSIDERATION,
 class UserProfile(models.Model):
 
     class Meta:
-         ordering = ['id']
+        ordering = ['id']
 
     user = models.OneToOneField(User)
     kv = models.ManyToManyField(KeyValue)

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
+from django.db.models import Q
 from django.db.models.signals import post_save
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -11,7 +12,8 @@ except ImportError:
     from urllib import parse as urlparse
 
 from wafer.kv.models import KeyValue
-from wafer.talks.models import ACCEPTED, PENDING
+from wafer.talks.models import (ACCEPTED, SUBMITTED, UNDER_CONSIDERATION,
+                                PROVISIONAL, CANCELLED)
 
 
 @python_2_unicode_compatible
@@ -37,8 +39,15 @@ class UserProfile(models.Model):
     def accepted_talks(self):
         return self.user.talks.filter(status=ACCEPTED)
 
+    def provisional_talks(self):
+        return self.user.talks.filter(status=PROVISIONAL)
+
     def pending_talks(self):
-        return self.user.talks.filter(status=PENDING)
+        return self.user.talks.filter(Q(status=SUBMITTED) |
+                                      Q(status=UNDER_CONSIDERATION))
+
+    def cancelled_talks(self):
+        return self.user.talks.filter(status=CANCELLED)
 
     def avatar_url(self, size=96, https=True, default='mm'):
         if not self.user.email:

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -73,7 +73,7 @@
 </div>
 {% endif %}
 {% if can_edit %}
-    {% if profile.pending_talks.exists or profile.accepted_talks.exists %}
+    {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
         {% if profile.is_registered %}
             <div class="tag tag-success">
                 {% blocktrans %}
@@ -103,10 +103,29 @@
 </div>
 {% endfor %}
 {% endif %}
+{% if profile.cancelled_talks.exists %}
+<h2>{% trans 'Cancelled Talks:' %}</h2>
+{% for talk in profile.cancelled_talks %}
+<div class="well">
+    <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
+    <p>{{ talk.abstract.rendered|safe }}</p>
+</div>
+{% endfor %}
+{% endif %}
+{% if profile.provisional_talks.exists %}
+<h2>{% trans 'Provisionally Accepted Talks:' %}</h2>
+{% for talk in profile.provisional_talks %}
+<div class="well">
+    <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
+    <p>{{ talk.abstract.rendered|safe }}</p>
+</div>
+{% endfor %}
+{% endif %}
+
 {# Submitted talk proposals are only visible to the owner #}
 {% if can_edit %}
 {% if profile.pending_talks.exists %}
-<h2>{% trans 'Submitted Talks (under consideration):' %}</h2>
+<h2>{% trans 'Submitted or Under Consideration Talks:' %}</h2>
 {% for talk in profile.pending_talks %}
 <div class="well">
     <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>


### PR DESCRIPTION
This replaces the 'PENDING' talk states with 2 states, 'SUBMITTED' and 'UNDER CONSIDERATION', since that better matches a typical review flow.

This also adds a 'PROVISIONALLY ACCEPTED' talk state, since proved a useful concept during Pycon ZA 2016.

Cancelled talks are now treated as public, and no longer invalidate the schedule, since that better matches the intended use case for that state.

The schedule still needs to distinguish between cancelled and accepted talks (see #301), but that is probably out of scope for this pull request.