### PR TITLE
Bugs/fix management cmds

### DIFF
--- a/wafer/management/commands/wafer_add_default_groups.py
+++ b/wafer/management/commands/wafer_add_default_groups.py
@@ -7,9 +7,6 @@ from django.contrib.auth.models import Group, Permission
 class Command(BaseCommand):
     help = "Add some useful default groups"
 
-    option_list = BaseCommand.option_list + tuple([
-    ])
-
     GROUPS = {
         # Permissions are specified as (app, code_name) pairs
         'Page Editors': (

--- a/wafer/management/commands/wafer_emails.py
+++ b/wafer/management/commands/wafer_emails.py
@@ -1,6 +1,5 @@
 import sys
 import csv
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
@@ -11,19 +10,18 @@ from wafer.talks.models import ACCEPTED
 class Command(BaseCommand):
     help = "List author or web-site user email addresses."
 
-    option_list = BaseCommand.option_list + tuple([
-        make_option('--authors', action="store_true", default=False,
-                    help='List author email addresses only'
-                    ' (for accepted talks)'),
-        make_option('--allauthors', action="store_true", default=False,
-                    help='List author emails only (for all talks)'),
-        make_option('--speakers', action="store_true", default=False,
-                    help='List speaker email addresses'
-                    ' (for accepted talks)'),
-        make_option('--allspeakers', action="store_true", default=False,
-                    help='List speaker email addresses'
-                    ' (for all talks)'),
-    ])
+    def add_arguments(self, parser):
+        parser.add_argument('--authors', action="store_true",
+                            help='List author email addresses only'
+                                 ' (for accepted talks)')
+        parser.add_argument('--allauthors', action="store_true",
+                            help='List author emails only (for all talks)')
+        parser.add_argument('--speakers', action="store_true",
+                            help='List speaker email addresses'
+                                 ' (for accepted talks)')
+        parser.add_argument('--allspeakers', action="store_true",
+                            help='List speaker email addresses'
+                                 ' (for all talks)')
 
     def _website_user_emails(self, options):
         query = {}

--- a/wafer/management/commands/wafer_speaker_contact_details.py
+++ b/wafer/management/commands/wafer_speaker_contact_details.py
@@ -1,6 +1,5 @@
 import sys
 import csv
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
@@ -11,14 +10,13 @@ from wafer.talks.models import ACCEPTED
 class Command(BaseCommand):
     help = "List contact details for the speakers."
 
-    option_list = BaseCommand.option_list + tuple([
-        make_option('--speakers', action="store_true", default=False,
-                    help='List speaker email addresses'
-                    ' (for accepted talks)'),
-        make_option('--allspeakers', action="store_true", default=False,
-                    help='List speaker email addresses'
-                    ' (for all talks)'),
-    ])
+    def add_arguments(self, parser):
+        parser.add_argument('--speakers', action="store_true",
+                            help='List speaker email addresses'
+                                 ' (for accepted talks)')
+        parser.add_argument('--allspeakers', action="store_true",
+                            help='List speaker email addresses'
+                                 ' (for all talks)')
 
     def _speaker_emails(self, options):
         people = get_user_model().objects.filter(

--- a/wafer/management/commands/wafer_speaker_tickets.py
+++ b/wafer/management/commands/wafer_speaker_tickets.py
@@ -1,6 +1,5 @@
 import sys
 import csv
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
@@ -13,10 +12,9 @@ class Command(BaseCommand):
             " speakers for accepted talk, but this can be overriden by"
             " the --all option")
 
-    option_list = BaseCommand.option_list + tuple([
-        make_option('--all', action="store_true", default=False,
-                    help='List speakers and tickets (for all talks)'),
-    ])
+    def add_arguments(self, parser):
+        parser.add_argument('--all', action="store_true",
+                            help='List speakers and tickets (for all talks)')
 
     def _speaker_tickets(self, options):
         people = get_user_model().objects.filter(

--- a/wafer/management/commands/wafer_stats.py
+++ b/wafer/management/commands/wafer_stats.py
@@ -6,9 +6,6 @@ from django.contrib.auth import get_user_model
 class Command(BaseCommand):
     help = "Misc stats."
 
-    option_list = BaseCommand.option_list + tuple([
-    ])
-
     def _speakers(self, *args, **kwargs):
         return get_user_model().objects.filter(
             contact_talks__isnull=False).filter(*args, **kwargs).count()


### PR DESCRIPTION
Django 1.8 deprecated the optparse argument handling in favour of argparse. Consequently the management commands are broken on recent Django versions.

This fixes them