### PR TITLE
Wrap cancelled items in del tag in schedule

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/schedule_item.html
+++ b/wafer/schedule/templates/wafer.schedule/schedule_item.html
@@ -1,7 +1,13 @@
 {% if item.talk %}
+  {% if item.talk.cancelled %}
+  <del class="talk-cancelled">
+  {% endif %}
   <a href="{{ item.get_url }}">{{ item.get_details|escape }}</a>
   <br>
   by {{ item.talk.get_authors_display_name }}
+  {% if item.talk.cancelled %}
+  </del>
+  {% endif %}
 {% elif item.get_url %}
   <a href="{{ item.get_url }}">{{ item.get_details|escape }}</a>
   {% if item.page and item.page.people.exists %}


### PR DESCRIPTION
To addresss #301, this wraps cancelled talks on the schedule with <del>.

Further styling may be desirable in the css, but this should do for a start.

We may want to do something similiar in the talk list, since the current 'C' label isn't that distinctive.