### PR TITLE
Features/add symbol to sponsor package

### DIFF
--- a/wafer/sponsors/migrations/0005_sponsorshippackage_symbol.py
+++ b/wafer/sponsors/migrations/0005_sponsorshippackage_symbol.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='sponsorshippackage',
             name='symbol',
-            field=models.CharField(help_text='Optional symbol to display next to sponsors backing at this level sponsors list', max_length=1, blank=True),
+            field=models.CharField(blank=True, help_text='Optional symbol to display in the sponsors list next to sponsors who have sponsored at this list, (for example *).', max_length=1),
         ),
     ]

--- a/wafer/sponsors/migrations/0005_sponsorshippackage_symbol.py
+++ b/wafer/sponsors/migrations/0005_sponsorshippackage_symbol.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sponsors', '0004_auto_20160813_1328'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sponsorshippackage',
+            name='symbol',
+            field=models.CharField(help_text='Optional symbol to display next to sponsors backing at this level sponsors list', max_length=1, blank=True),
+        ),
+    ]

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -39,6 +39,10 @@ class SponsorshipPackage(models.Model):
         File, related_name="packages", blank=True,
         help_text=_("Images and other files for use in"
                     " the description markdown field."))
+    symbol = models.CharField(
+        max_length=1, blank=True,
+        help_text=_("Optional symbol to display next to sponsors "
+                    "backing at this level sponsors list"))
 
     class Meta:
         ordering = ['order', '-price', 'name']

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -39,10 +39,13 @@ class SponsorshipPackage(models.Model):
         File, related_name="packages", blank=True,
         help_text=_("Images and other files for use in"
                     " the description markdown field."))
+    # We use purely ascii help text, to avoid issues with the migrations
+    # not handling unicode help text nicely.
     symbol = models.CharField(
         max_length=1, blank=True,
-        help_text=_("Optional symbol to display next to sponsors "
-                    "backing at this level sponsors list"))
+        help_text=_("Optional symbol to display in the sponsors list "
+                    "next to sponsors who have sponsored at this list, "
+                    "(for example *)."))
 
     class Meta:
         ordering = ['order', '-price', 'name']

--- a/wafer/sponsors/templates/wafer.sponsors/packages.html
+++ b/wafer/sponsors/templates/wafer.sponsors/packages.html
@@ -13,6 +13,10 @@
         {% endif %}
         <p>{% trans 'Packages claimed:' %} {{ package.number_claimed }}</p>
 
+        {% if package.symbol %}
+            <p>Symbol shown in the sponsor list: {{ package.symbol }}</p>
+        {% endif %}
+
         <p>{{ package.short_description }}</p>
         {{ package.description.rendered|safe }}
     </div>

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors.html
@@ -8,8 +8,8 @@
     <section class="wafer wafer-sponsor">
     <div class="well">
       <h2 class="bs-callout bs-callout-default bs-callout-{{ sponsor.packages.first.name.lower }}">
-         {% if sponsor.packages.first.name.lower == 'platinum' %}
-            ★
+         {% if sponsor.packages.first.symbol %}
+             {{ sponsor.packages.first.symbol }}
          {% endif %}
          {% if sponsor.url %}
          <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>


### PR DESCRIPTION
As discussed in #277, wafer currently uses a bit of hackery on the package name to add the '★' symbol for platinum sponsors. This is problematic for conferences using different sponsor package naming conventions, and not very flexible.

This adds an explicit 'symbol' field to make this customisable as part of the sponsor package.

This is currently restricted to single character symbols. We maybe should allow more complicated combinations here, but it's not clear to me what a good limit should be.