### PR TITLE
Use static tag, to allow for better caching

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -1,4 +1,5 @@
 {% extends "wafer/base.html" %}
+{% load static from staticfiles %}
 {% block content %}
     <div class="row">
         <div class="col-md-12">
@@ -142,5 +143,5 @@
 {% endblock %}
 
 {% block extra_foot %}
-<script src="{{ STATIC_URL }}js/edit_schedule.js"></script>
+<script src="{% static 'js/edit_schedule.js' %}"></script>
 {% endblock %}

--- a/wafer/templates/wafer/base.html
+++ b/wafer/templates/wafer/base.html
@@ -1,4 +1,5 @@
 {% load sponsors %}
+{% load static from staticfiles %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,9 +7,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{{ STATIC_URL }}vendor/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" media="screen">
-    <link href="{{ STATIC_URL }}vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" media="screen">
-    <link href="{{ STATIC_URL }}css/wafer.css" rel="stylesheet" media="screen">
+    <link href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet" media="screen">
+    <link href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet" media="screen">
+    <link href="{% static 'css/wafer.css' %}" rel="stylesheet" media="screen">
     {% block extra_head %}{% endblock %}
 </head>
 <body>
@@ -31,8 +32,8 @@
 {% endblock %}
     </div>
     {% sponsors %}
-    <script src="{{ STATIC_URL }}vendor/jquery/dist/jquery.min.js"></script>
-    <script src="{{ STATIC_URL }}vendor/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script src="{% static 'vendor/jquery/dist/jquery.min.js' %}"></script>
+    <script src="{% static 'vendor/bootstrap/dist/js/bootstrap.min.js' %}"></script>
     {% block extra_foot %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Some of the staticfiles backends, like ManifestStaticFilesStorage, will
alter the URLs of static assets, to allow them to be served with far
future expiry. This (naturally) makes a huge performance difference.