### PR TITLE
More bootstrap4 nav fixes

### DIFF
--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -2,7 +2,7 @@
 <nav class="navbar navbar-dark bg-inverse {{ WAFER_NAVIGATION_VISIBILITY }}">
   <div class="container">
     {% block navtogglebutton %}
-    <button type="button" class="navbar-toggler float-xs-right hidden-sm-up" data-toggle="collapse" data-target="#wafer-navbar-collapse" aria-controls="#wafer-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"></button>
+    <button type="button" class="navbar-toggler hidden-sm-up" data-toggle="collapse" data-target="#wafer-navbar-collapse" aria-controls="#wafer-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"></button>
     {% endblock navtogglebutton %}
 
     {% block navtitle %}

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<nav class="navbar navbar-dark bg-inverse navbar-static-top {{ WAFER_NAVIGATION_VISIBILITY }}">
+<nav class="navbar navbar-dark bg-inverse {{ WAFER_NAVIGATION_VISIBILITY }}">
   <div class="container">
     {% block navtogglebutton %}
     <button type="button" class="navbar-toggler float-xs-right hidden-sm-up" data-toggle="collapse" data-target="#wafer-navbar-collapse">

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -41,7 +41,7 @@
       </ul>
       {% endblock navmenulist %}
       {% block navauthmenu %}
-      <ul class="nav navbar-nav float-xs-right">
+      <ul class="nav navbar-nav float-sm-right">
         {% if user.is_authenticated %}
         {% block navauthenticated %}
         <li class="nav-item dropdown">

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -2,12 +2,7 @@
 <nav class="navbar navbar-dark bg-inverse {{ WAFER_NAVIGATION_VISIBILITY }}">
   <div class="container">
     {% block navtogglebutton %}
-    <button type="button" class="navbar-toggler float-xs-right hidden-sm-up" data-toggle="collapse" data-target="#wafer-navbar-collapse">
-      <span class="sr-only">
-         Toggle navigation
-      </span>
-      &#9776;
-    </button>
+    <button type="button" class="navbar-toggler float-xs-right hidden-sm-up" data-toggle="collapse" data-target="#wafer-navbar-collapse" aria-controls="#wafer-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"></button>
     {% endblock navtogglebutton %}
 
     {% block navtitle %}


### PR DESCRIPTION
#330 introduced a regression - the menu misbehaved when the hamburger was expanded. This puts the hamburger back on the left, which makes things work again. I can't figure out how to get it to work, on the right.

Also, the expand button had a double hamburger on it.