### PR TITLE
Feature/files with names

### DIFF
--- a/wafer/pages/migrations/0004_allow_blank_files_description.py
+++ b/wafer/pages/migrations/0004_allow_blank_files_description.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0003_non-null_people+files'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='file',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -18,7 +18,7 @@ from wafer.menu import MenuError, refresh_menu_cache
 class File(models.Model):
     """A file for use in page markup."""
     name = models.CharField(max_length=255)
-    description = models.TextField()
+    description = models.TextField(blank=True)
     item = models.FileField(upload_to='pages_files')
 
     def __str__(self):

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -49,7 +49,8 @@ class Page(models.Model):
         help_text=_("Images and other files for use in"
                     " the content markdown field."))
 
-    people = models.ManyToManyField(settings.AUTH_USER_MODEL,
+    people = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
         related_name='pages', blank=True,
         help_text=_("People associated with this page for display in the"
                     " schedule (Session chairs, panelists, etc.)"))

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -22,7 +22,11 @@ class File(models.Model):
     item = models.FileField(upload_to='pages_files')
 
     def __str__(self):
-        return u'%s' % (self.name,)
+        if self.pages.exists():
+            pages = ' & '.join([x.name for x in self.pages.all()])
+            return u'<%s>: %s (%s)' % (pages, self.name, self.item.url)
+        else:
+            return u'<No Page>: %s (%s)' % (self.name, self.item.url)
 
 
 @python_2_unicode_compatible

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -22,11 +22,7 @@ class File(models.Model):
     item = models.FileField(upload_to='pages_files')
 
     def __str__(self):
-        if self.pages.exists():
-            pages = ' & '.join([x.name for x in self.pages.all()])
-            return u'<%s>: %s (%s)' % (pages, self.name, self.item.url)
-        else:
-            return u'<No Page>: %s (%s)' % (self.name, self.item.url)
+        return u'%s (%s)' % (self.name, self.item.url)
 
 
 @python_2_unicode_compatible

--- a/wafer/sponsors/migrations/0006_allow_blank_files_description.py
+++ b/wafer/sponsors/migrations/0006_allow_blank_files_description.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sponsors', '0005_sponsorshippackage_symbol'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='file',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -15,7 +15,11 @@ class File(models.Model):
     item = models.FileField(upload_to='sponsors_files')
 
     def __str__(self):
-        return u'%s' % (self.name,)
+        if self.sponsors.exists():
+            sponsors = ' & '.join([x.name for x in self.sponsors.all()])
+            return u'<%s>: %s (%s)' % (sponsors, self.name, self.item.url)
+        else:
+            return u'<No Sponsor>: %s (%s)' % (self.name, self.item.url)
 
 
 @python_2_unicode_compatible

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -15,11 +15,7 @@ class File(models.Model):
     item = models.FileField(upload_to='sponsors_files')
 
     def __str__(self):
-        if self.sponsors.exists():
-            sponsors = ' & '.join([x.name for x in self.sponsors.all()])
-            return u'<%s>: %s (%s)' % (sponsors, self.name, self.item.url)
-        else:
-            return u'<No Sponsor>: %s (%s)' % (self.name, self.item.url)
+        return u'%s (%s)' % (self.name, self.item.url)
 
 
 @python_2_unicode_compatible

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -11,7 +11,7 @@ from markitup.fields import MarkupField
 class File(models.Model):
     """A file for use in sponsor and sponshorship package descriptions."""
     name = models.CharField(max_length=255)
-    description = models.TextField()
+    description = models.TextField(blank=True)
     item = models.FileField(upload_to='sponsors_files')
 
     def __str__(self):

--- a/wafer/sponsors/models.py
+++ b/wafer/sponsors/models.py
@@ -74,9 +74,9 @@ class Sponsor(models.Model):
         File, related_name="sponsors", blank=True,
         help_text=_("Images and other files for use in"
                     " the description markdown field."))
-    url = models.URLField(default="",
-            blank=True,
-            help_text=_("Url to link back to the sponsor if required"))
+    url = models.URLField(
+        default="", blank=True,
+        help_text=_("Url to link back to the sponsor if required"))
 
     class Meta:
         ordering = ['order', 'name', 'id']

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
@@ -1,3 +1,4 @@
+{% load sponsors %}
 <div id="wafer-sponsors">
     {% for package in packages %}
     {% if package.sponsors.exists %}
@@ -6,8 +7,9 @@
             <ul>
                 {% for sponsor in package.sponsors.all %}
                     <li>
-                        {% if sponsor.logo %}
-                            <img src="{{ sponsor.logo.url }}" alt="{{ sponsor.name }}">
+                        {% sponsor_image_url "logo.png" as logo_url %}
+                        {% if logo_url != '' %}
+                            <img src="{{ logo_url }}" alt="{{ sponsor.name }}">
                         {% else %}
                             <span class="nologo">{{ sponsor.name }}</span>
                         {% endif %}

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
@@ -7,7 +7,7 @@
             <ul>
                 {% for sponsor in package.sponsors.all %}
                     <li>
-                        {% sponsor_image_url "logo.png" as logo_url %}
+                        {% sponsor_image_url sponsor "logo.png" as logo_url %}
                         {% if logo_url != '' %}
                             <img src="{{ logo_url }}" alt="{{ sponsor.name }}">
                         {% else %}

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors_block.html
@@ -7,7 +7,7 @@
             <ul>
                 {% for sponsor in package.sponsors.all %}
                     <li>
-                        {% sponsor_image_url sponsor "logo.png" as logo_url %}
+                        {% sponsor_image_url sponsor "logo" as logo_url %}
                         {% if logo_url != '' %}
                             <img src="{{ logo_url }}" alt="{{ sponsor.name }}">
                         {% else %}

--- a/wafer/sponsors/templatetags/sponsors.py
+++ b/wafer/sponsors/templatetags/sponsors.py
@@ -11,3 +11,17 @@ def sponsors():
         'sponsors': Sponsor.objects.all().order_by('packages'),
         'packages': SponsorshipPackage.objects.all().prefetch_related('files'),
     }
+
+
+# We use assignment_tag for compatibility with Django 1.8
+# Once we drop 1.8 support, we should change this to
+# simple_tag
+@register.assignment_tag(takes_context=True)
+def sponsor_image_url(context, name):
+    """Returns the corresponding url from the sponsors images"""
+    sponsor = context['sponsor']
+    if sponsor.files.filter(name=name).exists():
+        # We avoid worrying about multiple matches by always
+        # returning the first one.
+        return sponsor.files.filter(name=name).first().item.url
+    return ''

--- a/wafer/sponsors/templatetags/sponsors.py
+++ b/wafer/sponsors/templatetags/sponsors.py
@@ -16,10 +16,9 @@ def sponsors():
 # We use assignment_tag for compatibility with Django 1.8
 # Once we drop 1.8 support, we should change this to
 # simple_tag
-@register.assignment_tag(takes_context=True)
-def sponsor_image_url(context, name):
+@register.assignment_tag()
+def sponsor_image_url(sponsor, name):
     """Returns the corresponding url from the sponsors images"""
-    sponsor = context['sponsor']
     if sponsor.files.filter(name=name).exists():
         # We avoid worrying about multiple matches by always
         # returning the first one.


### PR DESCRIPTION
As mentioned in #213 , the current assumptions requires specifying the same name for the images associated with each sponsor, which is confusing in the admin.

This changes the str representation for files added via pages and sponsors to include more information (associated objects & the path) to make it easier to distinguish between the files.

It also adds a template tag to simplify looking up images associated with a sponsor.