### PR TITLE
Feature/django 1.11 travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ matrix:
       - python: "2.7"
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
-allow_failures:
-  - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=postgres
-  - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=sqlite
-  - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
-  - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+   allow_failures:
+      - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=postgres
+      - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=sqlite
+      - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
+      - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
 
 services:
    - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
    - DJANGO='django>=1.9.0,<1.10.0' TESTDB=postgres
    - DJANGO='django>=1.10.0,<1.11.0' TESTDB=sqlite
    - DJANGO='django>=1.10.0,<1.11.0' TESTDB=postgres
+   - DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=sqlite
+   - DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=postgres
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
@@ -34,6 +36,8 @@ matrix:
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
 allow_failures:
+  - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=postgres
+  - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=sqlite
   - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
   - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
    - "2.7"
-   - "3.3"
    - "3.4"
    - "3.5"
 env:
@@ -19,16 +18,6 @@ env:
 
 matrix:
    exclude:
-      # Django no longer supports 3.3
-      - python: "3.3"
-        env: DJANGO='django>=1.9.0,<1.10.0' TESTDB=sqlite
-      - python: "3.3"
-        env: DJANGO='django>=1.9.0,<1.10.0' TESTDB=postgres
-      - python: "3.3"
-        env: DJANGO='django>=1.10.0,<1.11.0' TESTDB=sqlite
-      - python: "3.3"
-        env: DJANGO='django>=1.10.0,<1.11.0' TESTDB=postgres
-      - python: "3.3"
       # Django 2.0 will drop python 2 support - https://www.djangoproject.com/weblog/2015/jun/25/roadmap/
       - python: "2.7"
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ matrix:
       - python: "3.3"
         env: DJANGO='django>=1.10.0,<1.11.0' TESTDB=postgres
       - python: "3.3"
+      # Django 2.0 will drop python 2 support - https://www.djangoproject.com/weblog/2015/jun/25/roadmap/
+      - python: "2.7"
+        env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
+      - python: "2.7"
+        env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
 allow_failures:
   - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres


### PR DESCRIPTION
This updates our .travis.yml file to fix a few things

Most importantly, it corrects an error with our use of allowed_failures.

It also separates testing of Django master and the 1.11 stable branch, since master is now heading towards Django 2.0 .