### PR TITLE
We should probably actually care about failures against 1.11 pre-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
    allow_failures:
-      - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=postgres
-      - env: DJANGO='https://github.com/django/django/archive/stable/1.11.x.tar.gz' TESTDB=sqlite
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
 


### PR DESCRIPTION
We'll need compatibility soon enough, and the tests currently pass, so seems worthwhile.