### PR TITLE
Handle non-unique permissions the same as other permission errors, rather than breaking later

### DIFF
--- a/wafer/management/commands/wafer_add_default_groups.py
+++ b/wafer/management/commands/wafer_add_default_groups.py
@@ -37,6 +37,7 @@ class Command(BaseCommand):
                     continue
                 except Permission.MultipleObjectsReturned:
                     print('Non-unique permission %s' % perm_code)
+                    continue
                 if perm not in group.permissions.all():
                     print('Adding %s to %s' % (perm_code, wafer_group))
                     group.permissions.add(perm)


### PR DESCRIPTION
The existing exception handling logic is wrong, erroring out immediately after the message beacuse ```perm``` is undefined. This makes the two exception paths behave in the same way.