### PR TITLE
Respect the next parameter during auth

### DIFF
--- a/wafer/registration/forms.py
+++ b/wafer/registration/forms.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit
+from crispy_forms.layout import Hidden, Submit
 
 
 class RegistrationFormHelper(FormHelper):
@@ -17,7 +17,8 @@ class RegistrationFormHelper(FormHelper):
 class LoginFormHelper(FormHelper):
     form_action = settings.LOGIN_URL
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, request, *args, **kwargs):
         super(LoginFormHelper, self).__init__(*args, **kwargs)
-        # TODO: next field
+        if 'next' in request.GET:
+            self.add_input(Hidden('next', request.GET['next']))
         self.add_input(Submit('submit', _('Log in')))

--- a/wafer/registration/templates/registration/login.html
+++ b/wafer/registration/templates/registration/login.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
+{% load wafer_sso %}
 {% block title %}Login - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <div class="container">
@@ -21,12 +22,10 @@
             <h2>{% trans 'Shared/Social Log in and Sign up' %}</h2>
             <ul>
                 {% if 'github' in WAFER_SSO %}
-                {% url 'wafer.registration.views.github_login' as github_sso_url %}
-                <li><a href="{{ github_sso_url }}">GitHub</a></li>
+                <li><a href="{% wafer_sso_url 'github' %}">GitHub</a></li>
                 {% endif %}
                 {% if 'debian' in WAFER_SSO %}
-                {% url 'wafer.registration.views.debian_login' as debian_sso_url %}
-                <li><a href="{{ debian_sso_url }}">Debian SSO</a></li>
+                <li><a href="{% wafer_sso_url 'debian' %}">Debian SSO</a></li>
                 {% endif %}
             </ul>
             {% endif %}

--- a/wafer/registration/templatetags/wafer_crispy.py
+++ b/wafer/registration/templatetags/wafer_crispy.py
@@ -4,15 +4,16 @@ import sys
 register = template.Library()
 
 
-@register.assignment_tag
-def wafer_form_helper(helper_name):
+@register.assignment_tag(takes_context=True)
+def wafer_form_helper(context, helper_name):
     '''
     Find the specified Crispy FormHelper and instantiate it.
     Handy when you are crispyifying other apps' forms.
     '''
+    request = context.request
     module, class_name = helper_name.rsplit('.', 1)
     if module not in sys.modules:
         __import__(module)
     mod = sys.modules[module]
     class_ = getattr(mod, class_name)
-    return class_()
+    return class_(request=request)

--- a/wafer/registration/templatetags/wafer_sso.py
+++ b/wafer/registration/templatetags/wafer_sso.py
@@ -1,6 +1,6 @@
-from urllib.parse import urlencode
 from django import template
 from django.core.urlresolvers import reverse
+from django.utils.http import urlencode
 
 register = template.Library()
 

--- a/wafer/registration/templatetags/wafer_sso.py
+++ b/wafer/registration/templatetags/wafer_sso.py
@@ -1,0 +1,17 @@
+from urllib.parse import urlencode
+from django import template
+from django.core.urlresolvers import reverse
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def wafer_sso_url(context, sso_method):
+    '''
+    Return the correct URL to SSO with the given method.
+    '''
+    request = context.request
+    url = reverse('wafer.registration.views.%s_login' % sso_method)
+    if 'next' in request.GET:
+        url += '?' + urlencode({'next': request.GET['next']})
+    return url

--- a/wafer/registration/views.py
+++ b/wafer/registration/views.py
@@ -1,11 +1,10 @@
-import urllib
-
 from django.contrib.auth import login
 from django.contrib.auth.views import redirect_to_login
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.http import Http404, HttpResponseRedirect
+from django.utils.http import urlencode
 
 from wafer.registration.sso import SSOError, debian_sso, github_sso
 
@@ -27,7 +26,7 @@ def github_login(request):
 
     if 'code' not in request.GET:
         return HttpResponseRedirect(
-            'https://github.com/login/oauth/authorize?' + urllib.urlencode({
+            'https://github.com/login/oauth/authorize?' + urlencode({
                 'client_id': settings.WAFER_GITHUB_CLIENT_ID,
                 'redirect_uri': request.build_absolute_uri(
                     reverse(github_login)),

--- a/wafer/registration/views.py
+++ b/wafer/registration/views.py
@@ -45,6 +45,9 @@ def github_login(request):
         return HttpResponseRedirect(reverse('auth_login'))
 
     login(request, user)
+
+    if 'next' in request.GET:
+        return HttpResponseRedirect(request.GET['next'])
     return redirect_profile(request)
 
 
@@ -59,4 +62,7 @@ def debian_login(request):
         return HttpResponseRedirect(reverse('auth_login'))
 
     login(request, user)
+
+    if 'next' in request.GET:
+        return HttpResponseRedirect(request.GET['next'])
     return redirect_profile(request)


### PR DESCRIPTION
The login form takes a next query parameter, so that a page that requires authentication can redirect to the login form, and then back to the desired page, once authenticated.