### PR TITLE
bootstrap4 alpha 6: tag -> badge rename

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -107,7 +107,7 @@
         <div role="tabpanel" class="tab-pane row"
              id="unassignedTalks">
           {% for talk in talks_unassigned %}
-            <span draggable="true" class="col-md-6 tag tag-success draggable"
+            <span draggable="true" class="col-md-6 badge badge-success draggable"
                   id="talk{{ talk.talk_id }}"
                   data-toggle="tooltip" data-placement="left"
                   title="{{ talk.title }}" data-type="talk" data-talk-id="{{ talk.talk_id }}">
@@ -118,7 +118,7 @@
         <div role="tabpanel" class="tab-pane active row"
              id="allTalks">
           {% for talk in talks_all %}
-            <span draggable="true" class="col-md-6 tag tag-warning draggable"
+            <span draggable="true" class="col-md-6 badge badge-warning draggable"
                   id="talk{{ talk.talk_id }}"
                   data-toggle="tooltip" data-placement="left"
                   title="{{ talk.title }}" data-type="talk" data-talk-id="{{ talk.talk_id }}">
@@ -128,7 +128,7 @@
         </div>
         <div role="tabpanel" class="tab-pane row" id="pages">
           {% for page in pages %}
-            <span draggable="true" class="col-md-6 tag tag-info draggable"
+            <span draggable="true" class="col-md-6 badge badge-info draggable"
                   id="page{{ page.id }}"
                   data-toggle="tooltip" data-placement="left"
                   title="{{ page.name }}" data-type="page" data-page-id="{{ page.id }}">

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -62,17 +62,17 @@
       <p>
         {% trans 'Status:' %}
         {% if object.submitted %}
-          <span class="tag tag-info">{% trans 'Submitted' %}</span>
+          <span class="badge badge-info">{% trans 'Submitted' %}</span>
         {% elif object.under_consideration %}
-          <span class="tag tag-info">{% trans 'Under consideration' %}</span>
+          <span class="badge badge-info">{% trans 'Under consideration' %}</span>
         {% elif object.provisional %}
-          <span class="tag tag-success">{% trans 'Provisionally Accepted' %}</span>
+          <span class="badge badge-success">{% trans 'Provisionally Accepted' %}</span>
         {% elif object.accepted %}
-          <span class="tag tag-success">{% trans 'Accepted' %}</span>
+          <span class="badge badge-success">{% trans 'Accepted' %}</span>
         {% elif object.cancelled %}
-          <span class="tag tag-warning">{% trans 'Cancelled' %}</span>
+          <span class="badge badge-warning">{% trans 'Cancelled' %}</span>
         {% else %}
-          <span class="tag tag-danger">{% trans 'Not accepted' %}</span>
+          <span class="badge badge-danger">{% trans 'Not accepted' %}</span>
         {% endif %}
       </p>
     </div>

--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -8,15 +8,15 @@
     {% for talk in talk_list %}
       <div>
         {% if talk.submitted %}
-          <span class="tag tag-info" title="{% trans 'Submitted' %}">{{ talk.status }}</span>
+          <span class="badge badge-info" title="{% trans 'Submitted' %}">{{ talk.status }}</span>
         {% elif talk.under_consideration %}
-          <span class="tag tag-info" title="{% trans 'Under consideration' %}">{{ talk.status }}</span>
+          <span class="badge badge-info" title="{% trans 'Under consideration' %}">{{ talk.status }}</span>
         {% elif talk.reject %}
-          <span class="tag tag-danger" title="{% trans 'Not accepted' %}">{{ talk.status }}</span>
+          <span class="badge badge-danger" title="{% trans 'Not accepted' %}">{{ talk.status }}</span>
         {% elif talk.cancelled %}
-          <span class="tag tag-warning" title="{% trans 'Talk Cancelled' %}">{{ talk.status }}</span>
+          <span class="badge badge-warning" title="{% trans 'Talk Cancelled' %}">{{ talk.status }}</span>
         {% elif talk.provisional %}
-          <span class="tag tag-success" title="{% trans 'Provisionally Accepted' %}">{{ talk.status }}</span>
+          <span class="badge badge-success" title="{% trans 'Provisionally Accepted' %}">{{ talk.status }}</span>
         {% endif %}
         <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
         by

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -76,7 +76,7 @@
 {% if can_edit %}
     {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
         {% if profile.is_registered %}
-            <div class="tag tag-success">
+            <div class="badge badge-success">
                 {% blocktrans %}
                     Registered
                 {% endblocktrans %}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -76,7 +76,7 @@
 {% if can_edit %}
     {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
         {% if profile.is_registered %}
-            <div class="badge badge-success">
+            <div class="alert alert-success">
                 {% blocktrans %}
                     Registered
                 {% endblocktrans %}


### PR DESCRIPTION
bootstrap4 alpha 6 renamed `tag` -> `badge` (and didn't document it at the time).
This was to avoid conflicting with WordPress, apparently.