### PR TITLE
Feature/add private notes to talk mentors

### DIFF
--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -26,8 +26,10 @@ Talk Mentors
 ============
 
 The ``Talk Mentors`` group has permission to view all talk submissions and
-to edit talks. They also have permission to view the notes submitted along
-with a talk.
+to edit talks. They have permission to view and the notes submitted along
+with a talk, which are visible to the talk submitter, and also have
+permission to view and edit the private notes which are only visible to
+the ``Talk Mentors`` and administrators by default.
 
 Managing talks from the admin interface
 =======================================

--- a/wafer/management/commands/wafer_add_default_groups.py
+++ b/wafer/management/commands/wafer_add_default_groups.py
@@ -16,6 +16,7 @@ class Command(BaseCommand):
         ),
         'Talk Mentors': (
             ('talks', 'change_talk'), ('talks', 'view_all_talks'),
+            ('talks', 'edit_private_notes'),
         ),
         'Registration': (),
     }


### PR DESCRIPTION
As discussed on IRC, mentors currently can't see the private notes, but probably should be able to.