### PR TITLE
Add ordering of paginated query results.

### DIFF
--- a/wafer/kv/views.py
+++ b/wafer/kv/views.py
@@ -3,6 +3,8 @@ from rest_framework import viewsets
 from wafer.kv.models import KeyValue
 from wafer.kv.serializers import KeyValueSerializer
 from wafer.kv.permissions import KeyValueGroupPermission
+from wafer.utils import order_results_by
+
 
 class KeyValueViewSet(viewsets.ModelViewSet):
     """API endpoint that allows key-value pairs to be viewed or edited."""
@@ -10,6 +12,7 @@ class KeyValueViewSet(viewsets.ModelViewSet):
     serializer_class = KeyValueSerializer
     permission_classes = (KeyValueGroupPermission, )
 
+    @order_results_by('key', 'id')
     def get_queryset(self):
         # Restrict the list to only those that match the user's
         # groups

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -248,7 +248,7 @@ class ScheduleItemViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows groups to be viewed or edited.
     """
-    queryset = ScheduleItem.objects.all()
+    queryset = ScheduleItem.objects.all().order_by('id')
     serializer_class = ScheduleItemSerializer
     permission_classes = (IsAdminUser, )
 

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -20,6 +20,7 @@ from wafer.talks.models import Talk, TalkType, TalkUrl, ACCEPTED, CANCELLED
 from wafer.talks.forms import get_talk_form_class
 from wafer.talks.serializers import TalkSerializer, TalkUrlSerializer
 from wafer.users.models import UserProfile
+from wafer.utils import order_results_by
 
 
 class EditOwnTalksMixin(object):
@@ -37,13 +38,14 @@ class UsersTalks(ListView):
     template_name = 'wafer.talks/talks.html'
     paginate_by = 25
 
+    @order_results_by('talk_id')
     def get_queryset(self):
         # self.request will be None when we come here via the static site
         # renderer
         if (self.request and Talk.can_view_all(self.request.user)):
             return Talk.objects.all()
-        return Talk.objects.filter( Q(status=ACCEPTED) |
-                                    Q(status=CANCELLED))
+        return Talk.objects.filter(Q(status=ACCEPTED) |
+                                   Q(status=CANCELLED))
 
 
 class TalkView(DetailView):
@@ -162,6 +164,7 @@ class TalksViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
     # XXX: Do we want to allow authors to edit talks via the API?
     permission_classes = (DjangoModelPermissionsOrAnonReadOnly, )
 
+    @order_results_by('talk_id')
     def get_queryset(self):
         # We override the default implementation to only show accepted talks
         # to people who aren't part of the management group
@@ -191,7 +194,7 @@ class TalkExistsPermission(BasePermission):
 
 class TalkUrlsViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
     """API endpoint that allows talks to be viewed or edited."""
-    queryset = TalkUrl.objects.all()
+    queryset = TalkUrl.objects.all().order_by('id')
     serializer_class = TalkUrlSerializer
     permission_classes = (DjangoModelPermissions, TalkExistsPermission)
 

--- a/wafer/utils.py
+++ b/wafer/utils.py
@@ -14,6 +14,19 @@ def normalize_unicode(u):
     return unicodedata.normalize('NFKD', u).encode('ascii', 'ignore')
 
 
+def order_results_by(*fields):
+    """A decorator that applies an ordering to the QuerySet returned by a
+       function.
+       """
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kw):
+            result = f(*args, **kw)
+            return result.order_by(*fields)
+        return wrapper
+    return decorator
+
+
 def cache_result(cache_key, timeout):
     """A decorator for caching the result of a function."""
     def decorator(f):


### PR DESCRIPTION
Without this paginated query results could in theory do really odd things (like miss some results and repeat others). In practice databases seem a bit kinder than this but Django complains during tests.