### PR TITLE
With the addition of provisional status, it makes more sense to defau…

### DIFF
--- a/wafer/management/commands/wafer_speaker_tickets.py
+++ b/wafer/management/commands/wafer_speaker_tickets.py
@@ -4,17 +4,20 @@ import csv
 from django.core.management.base import BaseCommand
 
 from django.contrib.auth import get_user_model
-from wafer.talks.models import ACCEPTED
+from wafer.talks.models import ACCEPTED, PROVISIONAL
 
 
 class Command(BaseCommand):
     help = ("List speakers and associated tickets. By default, only lists"
-            " speakers for accepted talk, but this can be overriden by"
-            " the --all option")
+            " speakers for provisionally accepted talks, but this can be"
+            " overriden by the --all or --accepted options")
 
     def add_arguments(self, parser):
         parser.add_argument('--all', action="store_true",
                             help='List speakers and tickets (for all talks)')
+        parser.add_argument('--accepted', action="store_true",
+                            help='List speakers and tickets (for'
+                                 ' fully accepted talks)')
 
     def _speaker_tickets(self, options):
         people = get_user_model().objects.filter(
@@ -26,9 +29,12 @@ class Command(BaseCommand):
             # accounts
             if options['all']:
                 titles = [x.title for x in person.talks.all()]
-            else:
+            elif options['accepted']:
                 titles = [x.title for x in
                           person.talks.filter(status=ACCEPTED)]
+            else:
+                titles = [x.title for x in
+                          person.talks.filter(status=PROVISIONAL)]
             if not titles:
                 continue
             tickets = person.ticket.all()


### PR DESCRIPTION
With the addition of provisional status, it is useful to check which speakers of provisionally accepted talks have tickets. Given that buying a ticket is a common proxy for changing a talk from provisionally accepted to fully accpeted, it makes sense to default to checking that, rather than accepted talks.

We add an option to check accepted talks, since that is still useful in some circumstances.