### PR TITLE
Don't include empty slots in penta XML

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -23,7 +23,7 @@
             {% if venue in row.items %}
               {# this is more than a little horrible, but will do for testing #}
               {% for row_venue, items in row.items.items %}
-                {% if row_venue == venue %}
+                {% if row_venue == venue and items.item %}
                   {# The event id is the ScheduleItem pk, which should be unique enough #}
                   <event id="{{ items.item.pk }}">
                     {# Not sure what to do about timezones here #}


### PR DESCRIPTION
DebConf17 has a schedule with lots of empty slots. confclerk doesn't like the XML.