### PR TITLE
Explicitly set on_delete to models.CASCADE for ForeignKeys.

### DIFF
--- a/wafer/kv/models.py
+++ b/wafer/kv/models.py
@@ -5,7 +5,7 @@ from jsonfield import JSONField
 
 
 class KeyValue(models.Model):
-    group = models.ForeignKey(Group)
+    group = models.ForeignKey(Group, on_delete=models.CASCADE)
     key = models.CharField(max_length=64, db_index=True)
     value = JSONField()
 

--- a/wafer/pages/models.py
+++ b/wafer/pages/models.py
@@ -31,7 +31,8 @@ class Page(models.Model):
     """An extra page for the site."""
     name = models.CharField(max_length=255)
     slug = models.SlugField(help_text=_("Last component of the page URL"))
-    parent = models.ForeignKey('self', null=True, blank=True)
+    parent = models.ForeignKey(
+        'self', null=True, blank=True, on_delete=models.CASCADE)
     content = MarkupField(
         help_text=_("Markdown contents for the page."))
     include_in_menu = models.BooleanField(

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -58,6 +58,7 @@ class Slot(models.Model):
     #      requirements.
 
     previous_slot = models.ForeignKey('self', null=True, blank=True,
+                                      on_delete=models.CASCADE,
                                       help_text=_("Previous slot if "
                                                   "applicable (slots should "
                                                   "have either a previous "
@@ -144,8 +145,10 @@ class ScheduleItem(models.Model):
     # Items can span multiple slots (tutorials, etc).
     slots = models.ManyToManyField(Slot)
 
-    talk = models.ForeignKey(Talk, null=True, blank=True)
-    page = models.ForeignKey(Page, null=True, blank=True)
+    talk = models.ForeignKey(
+        Talk, null=True, blank=True, on_delete=models.CASCADE)
+    page = models.ForeignKey(
+        Page, null=True, blank=True, on_delete=models.CASCADE)
     details = MarkdownTextField(
         null=False, blank=True,
         help_text=_("Additional details (if required)"))

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -112,8 +112,10 @@ class Talk(models.Model):
     )
 
     talk_id = models.AutoField(primary_key=True)
-    talk_type = models.ForeignKey(TalkType, null=True, blank=True)
-    track = models.ForeignKey(Track, null=True, blank=True)
+    talk_type = models.ForeignKey(
+        TalkType, null=True, blank=True, on_delete=models.CASCADE)
+    track = models.ForeignKey(
+        Track, null=True, blank=True, on_delete=models.CASCADE)
 
     title = models.CharField(max_length=1024)
 
@@ -137,6 +139,7 @@ class Talk(models.Model):
 
     corresponding_author = models.ForeignKey(
         settings.AUTH_USER_MODEL, related_name='contact_talks',
+        on_delete=models.CASCADE,
         help_text=_(
             "The person submitting the talk (and who questions regarding the "
             "talk should be addressed to)."))
@@ -260,4 +263,4 @@ class TalkUrl(models.Model):
 
     description = models.CharField(max_length=256)
     url = models.URLField()
-    talk = models.ForeignKey(Talk)
+    talk = models.ForeignKey(Talk, on_delete=models.CASCADE)

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -113,9 +113,9 @@ class Talk(models.Model):
 
     talk_id = models.AutoField(primary_key=True)
     talk_type = models.ForeignKey(
-        TalkType, null=True, blank=True, on_delete=models.CASCADE)
+        TalkType, null=True, blank=True, on_delete=models.SET_NULL)
     track = models.ForeignKey(
-        Track, null=True, blank=True, on_delete=models.CASCADE)
+        Track, null=True, blank=True, on_delete=models.SET_NULL)
 
     title = models.CharField(max_length=1024)
 

--- a/wafer/tickets/models.py
+++ b/wafer/tickets/models.py
@@ -18,9 +18,10 @@ class TicketType(models.Model):
 class Ticket(models.Model):
     barcode = models.IntegerField(primary_key=True)
     email = models.EmailField(blank=True)
-    type = models.ForeignKey(TicketType)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='ticket',
-                             blank=True, null=True, on_delete=models.SET_NULL)
+    type = models.ForeignKey(TicketType, on_delete=models.CASCADE)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, related_name='ticket',
+        blank=True, null=True, on_delete=models.SET_NULL)
 
     def __str__(self):
         return u'%s (%s)' % (self.barcode, self.email)


### PR DESCRIPTION
As described in https://docs.djangoproject.com/en/1.11/ref/models/fields/#django.db.models.ForeignKey.on_delete explicitly setting `on_delete` is required in Django 2.0.