### PR TITLE
Tweak logic around clashes and invalid venues, so errors show correctly in the admin interface

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -112,7 +112,8 @@ def find_clashes(all_items):
                 clashes[pos].append(item)
             else:
                 seen_venue_slots[pos] = item
-    return clashes
+    # We return a list, to match other validators
+    return clashes.items()
 
 
 def find_invalid_venues(all_items):
@@ -130,7 +131,7 @@ def find_invalid_venues(all_items):
         if not valid:
             venues.setdefault(item.venue, [])
             venues[item.venue].append(item)
-    return venues
+    return venues.items()
 
 
 # Helper methods for calling the validators

--- a/wafer/schedule/templates/admin/scheduleitem_list.html
+++ b/wafer/schedule/templates/admin/scheduleitem_list.html
@@ -12,10 +12,10 @@
           {% if errors.clashes %}
           <h3>{% trans "Clashes" %}</h3>
           <ul>
-             {% for pos, items in errors.clashes.items %}
-             <li>{{ pos.0 }} at {{ pos.1.get_start_time|time:"H:i" }} --
+             {% for pos, items in errors.clashes %}
+             <li>{{ pos.0 }} at {{ items.0.get_start_time }} --
                  {% for item in items %}
-                     {{ item }},
+                 <b>{{ item.get_desc|escape }}</b>,
                  {% endfor %}
              </li>
              {% endfor %}
@@ -48,10 +48,10 @@
           {% if errors.venues %}
           <h3>{% trans "Venues assigned on days they are not available" %}</h3>
           <ul>
-             {% for venue, items in errors.venues.items %}
-             <li>{{ venue }} --
+             {% for venue, items in errors.venues %}
+             <li>{{ venue }} at {{ items.0.get_start_time }} --
                  {% for item in items %}
-                    {{ item }},
+                 <b>{{ item.get_desc|escape }}</b>,
                  {% endfor %}
              </li>
              {% endfor %}


### PR DESCRIPTION
The current logic for displaying errors loses the details for clashes and invalid venues, which makes debugging schedule issues harder than it should be.

This fixes the missing information problem.