### PR TITLE
Feature/drop old django support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       - python: "2.7"
         env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
       - python: "2.7"
-        env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
+        env: DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
       - python: "2.7"
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
       - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,13 @@ language: python
 sudo: false
 python:
    - "2.7"
-   - "3.4"
    - "3.5"
+   - "3.6"
 env:
-   - DJANGO='django>=1.8.0,<1.9.0' TESTDB=sqlite
-   - DJANGO='django>=1.8.0,<1.9.0' TESTDB=postgres
-   - DJANGO='django>=1.9.0,<1.10.0' TESTDB=sqlite
-   - DJANGO='django>=1.9.0,<1.10.0' TESTDB=postgres
-   - DJANGO='django>=1.10.0,<1.11.0' TESTDB=sqlite
-   - DJANGO='django>=1.10.0,<1.11.0' TESTDB=postgres
    - DJANGO='django>=1.11.0,<1.12.0' TESTDB=sqlite
    - DJANGO='django>=1.11.0,<1.12.0' TESTDB=postgres
+   - DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
+   - DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
@@ -20,11 +16,17 @@ matrix:
    exclude:
       # Django 2.0 will drop python 2 support - https://www.djangoproject.com/weblog/2015/jun/25/roadmap/
       - python: "2.7"
+        env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
+      - python: "2.7"
+        env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
+      - python: "2.7"
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
       - python: "2.7"
         env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
    allow_failures:
+      - env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
+      - env: DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=1.8',
+    'Django>=1.11',
     'django-crispy-forms',
     'django-nose',
     'django-registration-redux',


### PR DESCRIPTION
This updates our minimum Django requirement to Django 1.11, as a better starting point for trying to work towards supporting Django 2.0.

It also reduces the Django test matrix accordingly, and adds separate test sets for Django 2.0 and Django master - Django 2.0 is an allowed failure until we actually work on supporting it.