### PR TITLE
Towards Django 2.0 support 

### DIFF
--- a/wafer/kv/migrations/0001_initial.py
+++ b/wafer/kv/migrations/0001_initial.py
@@ -20,7 +20,8 @@ class Migration(migrations.Migration):
                                         auto_created=True, primary_key=True)),
                 ('key', models.CharField(max_length=64, db_index=True)),
                 ('value', jsonfield.fields.JSONField()),
-                ('group', models.ForeignKey(to='auth.Group')),
+                ('group', models.ForeignKey(
+                    to='auth.Group', on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/wafer/kv/migrations/0001_initial.py
+++ b/wafer/kv/migrations/0001_initial.py
@@ -16,7 +16,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='KeyValue',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID', serialize=False,
+                                        auto_created=True, primary_key=True)),
                 ('key', models.CharField(max_length=64, db_index=True)),
                 ('value', jsonfield.fields.JSONField()),
                 ('group', models.ForeignKey(to='auth.Group')),

--- a/wafer/pages/migrations/0001_initial.py
+++ b/wafer/pages/migrations/0001_initial.py
@@ -35,7 +35,8 @@ class Migration(migrations.Migration):
                 ('_content_rendered', models.TextField(editable=False, blank=True)),
                 ('files', models.ManyToManyField(help_text='Images and other files for use in the content markdown field.', related_name='pages', null=True, to='pages.File', blank=True)),
                 ('parent', models.ForeignKey(
-                    blank=True, to='pages.Page', null=True)),
+                    blank=True, to='pages.Page', null=True,
+                    on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/wafer/pages/migrations/0001_initial.py
+++ b/wafer/pages/migrations/0001_initial.py
@@ -34,7 +34,8 @@ class Migration(migrations.Migration):
                 ('exclude_from_static', models.BooleanField(default=False, help_text='Whether to exclude this page from the static version of the site (Container pages, etc.)')),
                 ('_content_rendered', models.TextField(editable=False, blank=True)),
                 ('files', models.ManyToManyField(help_text='Images and other files for use in the content markdown field.', related_name='pages', null=True, to='pages.File', blank=True)),
-                ('parent', models.ForeignKey(blank=True, to='pages.Page', null=True)),
+                ('parent', models.ForeignKey(
+                    blank=True, to='pages.Page', null=True)),
             ],
             options={
             },

--- a/wafer/registration/templatetags/wafer_crispy.py
+++ b/wafer/registration/templatetags/wafer_crispy.py
@@ -4,7 +4,7 @@ import sys
 register = template.Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def wafer_form_helper(context, helper_name):
     '''
     Find the specified Crispy FormHelper and instantiate it.

--- a/wafer/schedule/migrations/0001_initial.py
+++ b/wafer/schedule/migrations/0001_initial.py
@@ -32,7 +32,8 @@ class Migration(migrations.Migration):
                 ('notes', models.TextField(help_text='Notes for the conference organisers', blank=True)),
                 ('css_class', models.CharField(help_text='Custom css class for this schedule item', max_length=128, blank=True)),
                 ('details_html', models.TextField(editable=False)),
-                ('page', models.ForeignKey(blank=True, to='pages.Page', null=True)),
+                ('page', models.ForeignKey(
+                    blank=True, to='pages.Page', null=True)),
             ],
             options={
             },
@@ -45,8 +46,12 @@ class Migration(migrations.Migration):
                 ('start_time', models.TimeField(help_text='Start time (if no previous slot)', null=True, blank=True)),
                 ('end_time', models.TimeField(help_text='Slot end time', null=True)),
                 ('name', models.CharField(help_text='Identifier for use in the admin panel', max_length=1024, null=True, blank=True)),
-                ('day', models.ForeignKey(blank=True, to='schedule.Day', help_text='Day for this slot', null=True)),
-                ('previous_slot', models.ForeignKey(blank=True, to='schedule.Slot', help_text='Previous slot', null=True)),
+                ('day', models.ForeignKey(
+                    blank=True, to='schedule.Day', null=True,
+                    help_text='Day for this slot')),
+                ('previous_slot', models.ForeignKey(
+                    blank=True, to='schedule.Slot', help_text='Previous slot',
+                    null=True)),
             ],
             options={
                 'ordering': ['end_time', 'start_time'],

--- a/wafer/schedule/migrations/0001_initial.py
+++ b/wafer/schedule/migrations/0001_initial.py
@@ -33,7 +33,8 @@ class Migration(migrations.Migration):
                 ('css_class', models.CharField(help_text='Custom css class for this schedule item', max_length=128, blank=True)),
                 ('details_html', models.TextField(editable=False)),
                 ('page', models.ForeignKey(
-                    blank=True, to='pages.Page', null=True)),
+                    blank=True, to='pages.Page', null=True,
+                    on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -48,10 +49,10 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(help_text='Identifier for use in the admin panel', max_length=1024, null=True, blank=True)),
                 ('day', models.ForeignKey(
                     blank=True, to='schedule.Day', null=True,
-                    help_text='Day for this slot')),
+                    help_text='Day for this slot', on_delete=models.PROTECT)),
                 ('previous_slot', models.ForeignKey(
                     blank=True, to='schedule.Slot', help_text='Previous slot',
-                    null=True)),
+                    null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ['end_time', 'start_time'],
@@ -86,13 +87,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='scheduleitem',
             name='talk',
-            field=models.ForeignKey(blank=True, to='talks.Talk', null=True),
+            field=models.ForeignKey(
+                blank=True, to='talks.Talk', null=True,
+                on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='scheduleitem',
             name='venue',
-            field=models.ForeignKey(to='schedule.Venue'),
+            field=models.ForeignKey(
+                to='schedule.Venue', on_delete=models.PROTECT),
             preserve_default=True,
         ),
     ]

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -121,7 +121,7 @@ TEMPLATES = [
 ]
 
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/wafer/sponsors/templatetags/sponsors.py
+++ b/wafer/sponsors/templatetags/sponsors.py
@@ -13,10 +13,7 @@ def sponsors():
     }
 
 
-# We use assignment_tag for compatibility with Django 1.8
-# Once we drop 1.8 support, we should change this to
-# simple_tag
-@register.assignment_tag()
+@register.simple_tag()
 def sponsor_image_url(sponsor, name):
     """Returns the corresponding url from the sponsors images"""
     if sponsor.files.filter(name=name).exists():

--- a/wafer/talks/migrations/0001_initial.py
+++ b/wafer/talks/migrations/0001_initial.py
@@ -16,14 +16,30 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Talk',
             fields=[
-                ('talk_id', models.AutoField(serialize=False, primary_key=True)),
+                ('talk_id', models.AutoField(
+                    serialize=False, primary_key=True)),
                 ('title', models.CharField(max_length=1024)),
-                ('abstract', markitup.fields.MarkupField(help_text='Write two or three paragraphs describing your talk. Who is your audience? What will they get out of it? What will you cover?<br />You can use Markdown syntax.', no_rendered_field=True)),
-                ('notes', models.TextField(help_text='Any notes for the conference organisers?', null=True, blank=True)),
-                ('status', models.CharField(default=b'P', max_length=1, choices=[(b'A', b'Accepted'), (b'R', b'Not Accepted'), (b'P', b'Under Consideration')])),
-                ('_abstract_rendered', models.TextField(editable=False, blank=True)),
-                ('authors', models.ManyToManyField(related_name='talks', to=settings.AUTH_USER_MODEL)),
-                ('corresponding_author', models.ForeignKey(related_name='contact_talks', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
+                ('abstract', markitup.fields.MarkupField(
+                    help_text='Write two or three paragraphs describing your '
+                              'talk. Who is your audience? What will they get '
+                              'out of it? What will you cover?<br />You can '
+                              'use Markdown syntax.',
+                    no_rendered_field=True)),
+                ('notes', models.TextField(
+                    help_text='Any notes for the conference organisers?',
+                    null=True, blank=True)),
+                ('status', models.CharField(
+                    default=b'P', max_length=1, choices=[
+                        (b'A', b'Accepted'),
+                        (b'R', b'Not Accepted'),
+                        (b'P', b'Under Consideration')])),
+                ('_abstract_rendered', models.TextField(
+                    editable=False, blank=True)),
+                ('authors', models.ManyToManyField(
+                    related_name='talks', to=settings.AUTH_USER_MODEL)),
+                ('corresponding_author', models.ForeignKey(
+                    related_name='contact_talks', to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -32,7 +48,9 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TalkType',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True,
+                    primary_key=True)),
                 ('name', models.CharField(max_length=255)),
                 ('description', models.TextField(max_length=1024)),
             ],
@@ -43,7 +61,9 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TalkUrl',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True,
+                    primary_key=True)),
                 ('description', models.CharField(max_length=256)),
                 ('url', models.URLField()),
                 ('talk', models.ForeignKey(to='talks.Talk',

--- a/wafer/talks/migrations/0001_initial.py
+++ b/wafer/talks/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('status', models.CharField(default=b'P', max_length=1, choices=[(b'A', b'Accepted'), (b'R', b'Not Accepted'), (b'P', b'Under Consideration')])),
                 ('_abstract_rendered', models.TextField(editable=False, blank=True)),
                 ('authors', models.ManyToManyField(related_name='talks', to=settings.AUTH_USER_MODEL)),
-                ('corresponding_author', models.ForeignKey(related_name='contact_talks', to=settings.AUTH_USER_MODEL)),
+                ('corresponding_author', models.ForeignKey(related_name='contact_talks', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -46,7 +46,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('description', models.CharField(max_length=256)),
                 ('url', models.URLField()),
-                ('talk', models.ForeignKey(to='talks.Talk')),
+                ('talk', models.ForeignKey(to='talks.Talk',
+                                           on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -55,7 +56,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='talk',
             name='talk_type',
-            field=models.ForeignKey(to='talks.TalkType', null=True),
+            field=models.ForeignKey(to='talks.TalkType', null=True,
+                                    on_delete=models.SET_NULL),
             preserve_default=True,
         ),
     ]

--- a/wafer/talks/migrations/0006_author_helptext.py
+++ b/wafer/talks/migrations/0006_author_helptext.py
@@ -25,6 +25,7 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 related_name='contact_talks', to=settings.AUTH_USER_MODEL,
                 help_text='The person submitting the talk (and who questions '
-                          'regarding the talk should be addressed to).'),
+                          'regarding the talk should be addressed to).',
+                on_delete=models.CASCADE),
         ),
     ]

--- a/wafer/talks/migrations/0006_author_helptext.py
+++ b/wafer/talks/migrations/0006_author_helptext.py
@@ -15,11 +15,16 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='talk',
             name='authors',
-            field=models.ManyToManyField(help_text='The speakers presenting the talk.', related_name='talks', to=settings.AUTH_USER_MODEL),
+            field=models.ManyToManyField(
+                help_text='The speakers presenting the talk.',
+                related_name='talks', to=settings.AUTH_USER_MODEL),
         ),
         migrations.AlterField(
             model_name='talk',
             name='corresponding_author',
-            field=models.ForeignKey(related_name='contact_talks', to=settings.AUTH_USER_MODEL, help_text='The person submitting the talk (and who questions regarding the talk should be addressed to).'),
+            field=models.ForeignKey(
+                related_name='contact_talks', to=settings.AUTH_USER_MODEL,
+                help_text='The person submitting the talk (and who questions '
+                          'regarding the talk should be addressed to).'),
         ),
     ]

--- a/wafer/talks/migrations/0012_add_tracks.py
+++ b/wafer/talks/migrations/0012_add_tracks.py
@@ -28,7 +28,8 @@ class Migration(migrations.Migration):
             model_name='talk',
             name='track',
             field=models.ForeignKey(null=True, blank=True, default=None,
-                                    to='talks.Track'),
+                                    to='talks.Track',
+                                    on_delete=models.SET_NULL),
             preserve_default=False,
         ),
     ]

--- a/wafer/tickets/migrations/0001_initial.py
+++ b/wafer/tickets/migrations/0001_initial.py
@@ -36,7 +36,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='ticket',
             name='type',
-            field=models.ForeignKey(to='tickets.TicketType'),
+            field=models.ForeignKey(
+                to='tickets.TicketType', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/wafer/urls.py
+++ b/wafer/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     url(r'^talks/', include('wafer.talks.urls')),
     url(r'^sponsors/', include('wafer.sponsors.urls')),
     url(r'^pages/', include('wafer.pages.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^markitup/', include('markitup.urls')),
     url(r'^schedule/', include('wafer.schedule.urls')),
     url(r'^tickets/', include('wafer.tickets.urls')),

--- a/wafer/users/migrations/0001_initial.py
+++ b/wafer/users/migrations/0001_initial.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import django.core.validators
 from django.db import models, migrations
 from django.conf import settings
 
@@ -24,7 +25,12 @@ class Migration(migrations.Migration):
                 ('homepage', models.CharField(
                     max_length=256, null=True, blank=True)),
                 ('twitter_handle', models.CharField(
-                    max_length=15, null=True, blank=True)),
+                    max_length=15, null=True, blank=True,
+                    validators=[
+                        django.core.validators.RegexValidator(
+                            '^[A-Za-z0-9_]{1,15}$',
+                            'Incorrectly formatted twitter handle')
+                    ])),
                 ('github_username', models.CharField(
                     max_length=32, null=True, blank=True)),
                 ('user', models.OneToOneField(

--- a/wafer/users/migrations/0001_initial.py
+++ b/wafer/users/migrations/0001_initial.py
@@ -27,7 +27,8 @@ class Migration(migrations.Migration):
                     max_length=15, null=True, blank=True)),
                 ('github_username', models.CharField(
                     max_length=32, null=True, blank=True)),
-                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(
+                    to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/wafer/users/migrations/0001_initial.py
+++ b/wafer/users/migrations/0001_initial.py
@@ -15,12 +15,18 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UserProfile',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('contact_number', models.CharField(max_length=16, null=True, blank=True)),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True,
+                    primary_key=True)),
+                ('contact_number', models.CharField(
+                    max_length=16, null=True, blank=True)),
                 ('bio', models.TextField(null=True, blank=True)),
-                ('homepage', models.CharField(max_length=256, null=True, blank=True)),
-                ('twitter_handle', models.CharField(max_length=15, null=True, blank=True)),
-                ('github_username', models.CharField(max_length=32, null=True, blank=True)),
+                ('homepage', models.CharField(
+                    max_length=256, null=True, blank=True)),
+                ('twitter_handle', models.CharField(
+                    max_length=15, null=True, blank=True)),
+                ('github_username', models.CharField(
+                    max_length=32, null=True, blank=True)),
                 ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -32,7 +32,7 @@ class UserProfile(models.Model):
     class Meta:
         ordering = ['id']
 
-    user = models.OneToOneField(User)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
     kv = models.ManyToManyField(KeyValue)
     contact_number = models.CharField(max_length=16, null=True, blank=True)
     bio = models.TextField(null=True, blank=True)


### PR DESCRIPTION
Mostly adding `on_delete` to migrations. Also, follow through on some other deprecations.

This seems to work, at least for basic functionality, haven't tried building a schedule.

`drf-extensions` doesn't support Django 2.0 yet, I tested with local hacks to it. I see the same things in master, so guess it should at least be importable in the next release (although possibly not working correctly, yet).
`django-markitup` doesn't support Django 2.0 yet, but I did some work on that, upstream: zsiciarz/django-markitup#21.