### PR TITLE
Load jQuery once and only once, in page foot

### DIFF
--- a/wafer/compare/templates/admin/wafer.compare/change_form.html
+++ b/wafer/compare/templates/admin/wafer.compare/change_form.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_urls %}
+{% load static from staticfiles %}
 {% block object-tools-items %}
     <li>
         <a href="{% url opts|admin_urlname:'history' original.pk|admin_urlquote %}" class="historylink">{% trans "History" %}</a>
@@ -12,4 +13,8 @@
             <a href="{% url 'admin:view_on_site' content_type_id original.pk %}" class="viewsitelink">{% trans "View on site" %}</a>
         </li>
     {% endif %}
+{% endblock %}
+{% block footer %}
+{{ block.super }}
+<script src="{% static 'js/markitup.js' %}"></script>
 {% endblock %}

--- a/wafer/pages/forms.py
+++ b/wafer/pages/forms.py
@@ -11,6 +11,7 @@ class PageForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(PageForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
+        self.helper.include_media = False
         self.helper.add_input(Submit('submit', 'Submit'))
 
     class Meta:

--- a/wafer/pages/templates/wafer.pages/page_form.html
+++ b/wafer/pages/templates/wafer.pages/page_form.html
@@ -1,10 +1,15 @@
 {% extends 'wafer/base.html' %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <section class="wafer wafer-page-edit">
 <h1>{% trans "Edit Page" %}</h1>
-{{ form.media }}
 {% crispy form %}
 </section>
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/pages/templates/wafer.pages/page_form.html
+++ b/wafer/pages/templates/wafer.pages/page_form.html
@@ -1,6 +1,7 @@
 {% extends 'wafer/base.html' %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% load static from staticfiles %}
 {% block extra_head %}
 {{ form.media.css }}
 {% endblock %}
@@ -12,4 +13,5 @@
 {% endblock %}
 {% block extra_foot %}
 {{ form.media.js }}
+<script type="text/javascript" src="{% static 'js/markitup.js' %}"></script>
 {% endblock %}

--- a/wafer/pages/templates/wafer.pages/page_form.html
+++ b/wafer/pages/templates/wafer.pages/page_form.html
@@ -1,10 +1,7 @@
-{% extends 'wafer/base.html' %}
+{% extends 'wafer/base_form.html' %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 {% load static from staticfiles %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <section class="wafer wafer-page-edit">
 <h1>{% trans "Edit Page" %}</h1>
@@ -12,6 +9,6 @@
 </section>
 {% endblock %}
 {% block extra_foot %}
-{{ form.media.js }}
+{{ block.super }}
 <script type="text/javascript" src="{% static 'js/markitup.js' %}"></script>
 {% endblock %}

--- a/wafer/registration/forms.py
+++ b/wafer/registration/forms.py
@@ -8,6 +8,7 @@ from crispy_forms.layout import Hidden, Submit
 
 class RegistrationFormHelper(FormHelper):
     form_action = reverse('registration_register')
+    include_media = False
 
     def __init__(self, request, *args, **kwargs):
         super(RegistrationFormHelper, self).__init__(*args, **kwargs)

--- a/wafer/registration/templates/registration/login.html
+++ b/wafer/registration/templates/registration/login.html
@@ -4,6 +4,9 @@
 {% load wafer_crispy %}
 {% load wafer_sso %}
 {% block title %}Login - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <div class="container">
     <div class="row">
@@ -32,4 +35,7 @@
         </div>
     </div>
 </div>
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/registration/templates/registration/login.html
+++ b/wafer/registration/templates/registration/login.html
@@ -1,12 +1,9 @@
-{% extends 'wafer/base.html' %}
+{% extends 'wafer/base_form.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
 {% load wafer_sso %}
 {% block title %}Login - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <div class="container">
     <div class="row">
@@ -35,7 +32,4 @@
         </div>
     </div>
 </div>
-{% endblock %}
-{% block extra_foot %}
-{{ form.media.js }}
 {% endblock %}

--- a/wafer/registration/templates/registration/registration_form.html
+++ b/wafer/registration/templates/registration/registration_form.html
@@ -1,15 +1,9 @@
-{% extends 'wafer/base.html' %}
+{% extends 'wafer/base_form.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <h1>{% trans 'Sign up' %}</h1>
 {% wafer_form_helper 'wafer.registration.forms.RegistrationFormHelper' as form_helper %}
 {% crispy form form_helper %}
-{% endblock %}
-{% block extra_foot %}
-{{ form.media.js }}
 {% endblock %}

--- a/wafer/registration/templates/registration/registration_form.html
+++ b/wafer/registration/templates/registration/registration_form.html
@@ -2,8 +2,14 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load wafer_crispy %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <h1>{% trans 'Sign up' %}</h1>
 {% wafer_form_helper 'wafer.registration.forms.RegistrationFormHelper' as form_helper %}
 {% crispy form form_helper %}
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -297,7 +297,10 @@ WAFER_PUBLIC_ATTENDEE_LIST = True
 # django_medusa -- disk-based renderer
 MEDUSA_RENDERER_CLASS = "wafer.management.static.WaferDiskStaticSiteRenderer"
 MEDUSA_DEPLOY_DIR = os.path.join(project_root, 'static_mirror')
+
 MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
+JQUERY_URL = None
+SELECT2_USE_BUNDLED_JQUERY = False
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAdminUser',),

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -150,7 +150,6 @@ INSTALLED_APPS = (
     'django_medusa',
     'crispy_forms',
     'django_nose',
-    'markitup',
     'rest_framework',
     'easy_select2',
     'wafer',
@@ -164,6 +163,7 @@ INSTALLED_APPS = (
     'wafer.tickets',
     'wafer.compare',
     # Django isn't finding the overridden templates
+    'markitup',
     'registration',
     'django.contrib.admin',
 )

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -299,7 +299,7 @@ MEDUSA_RENDERER_CLASS = "wafer.management.static.WaferDiskStaticSiteRenderer"
 MEDUSA_DEPLOY_DIR = os.path.join(project_root, 'static_mirror')
 
 MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
-JQUERY_URL = None
+JQUERY_URL = 'vendor/jquery/dist/jquery.min.js'
 SELECT2_USE_BUNDLED_JQUERY = False
 
 REST_FRAMEWORK = {

--- a/wafer/sponsors/templates/admin/sponsors/change_form.html
+++ b/wafer/sponsors/templates/admin/sponsors/change_form.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_form.html" %}
+{% load static from staticfiles %}
+{% block footer %}
+{{ block.super }}
+<script src="{% static 'js/markitup.js' %}"></script>
+{% endblock %}

--- a/wafer/static/js/markitup.js
+++ b/wafer/static/js/markitup.js
@@ -2,7 +2,7 @@
 $('.django-markitup-config').each(function(index) {
   var element = $(this.getAttribute('data-element'));
   var preview_url = this.getAttribute('data-preview-url');
-  var auto_preview = this.getAttribute('data-auto-preview');
+  var auto_preview = this.getAttribute('data-auto-preview') == '1';
   if (!element.hasClass("markItUpEditor")) {
     if (preview_url) {
       mySettings["previewParserPath"] = preview_url;

--- a/wafer/static/js/markitup.js
+++ b/wafer/static/js/markitup.js
@@ -1,0 +1,15 @@
+'use strict'
+$('.django-markitup-config').each(function(index) {
+  var element = $(this.getAttribute('data-element'));
+  var preview_url = this.getAttribute('data-preview-url');
+  var auto_preview = this.getAttribute('data-auto-preview');
+  if (!element.hasClass("markItUpEditor")) {
+    if (preview_url) {
+      mySettings["previewParserPath"] = preview_url;
+    }
+    element.markItUp(mySettings);
+  }
+  if (auto_preview) {
+    $('a[title="Preview"]').trigger('mouseup');
+  }
+});

--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -100,6 +100,7 @@ class TalkForm(forms.ModelForm):
         self.fields['authors'].label_from_instance = render_author
 
         self.helper = FormHelper(self)
+        self.helper.include_media = False
         submit_button = Submit('submit', _('Submit'))
         instance = kwargs['instance']
         if instance:

--- a/wafer/talks/templates/wafer.talks/talk_form.html
+++ b/wafer/talks/templates/wafer.talks/talk_form.html
@@ -1,6 +1,9 @@
 {% extends 'wafer/base.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <section class="wafer wafer-talk-edit">
   {% if can_edit %}
@@ -19,8 +22,10 @@
       <em>Talk submission is closed</em>
     {% endblocktrans %}
   {% else %}
-    {{ form.media }}
     {% crispy form %}
   {% endif %}
 </section>
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_form.html
+++ b/wafer/talks/templates/wafer.talks/talk_form.html
@@ -1,10 +1,7 @@
-{% extends 'wafer/base.html' %}
+{% extends 'wafer/base_form.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load static from staticfiles %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <section class="wafer wafer-talk-edit">
   {% if can_edit %}
@@ -28,6 +25,6 @@
 </section>
 {% endblock %}
 {% block extra_foot %}
-{{ form.media.js }}
+{{ block.super }}
 <script type="text/javascript" src="{% static 'js/markitup.js' %}"></script>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_form.html
+++ b/wafer/talks/templates/wafer.talks/talk_form.html
@@ -1,6 +1,7 @@
 {% extends 'wafer/base.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% load static from staticfiles %}
 {% block extra_head %}
 {{ form.media.css }}
 {% endblock %}
@@ -28,4 +29,5 @@
 {% endblock %}
 {% block extra_foot %}
 {{ form.media.js }}
+<script type="text/javascript" src="{% static 'js/markitup.js' %}"></script>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_withdraw.html
+++ b/wafer/talks/templates/wafer.talks/talk_withdraw.html
@@ -1,6 +1,9 @@
 {% extends 'wafer/base.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <section class="wafer wafer-talk-withdrawal">
   <h1>{% trans "Confirm Talk Withdrawal" %}</h1>
@@ -15,4 +18,7 @@
     <input type="submit" class="btn btn-danger" value="{% trans 'Confirm Withdrawal' %}">
   </form>
 </section>
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_withdraw.html
+++ b/wafer/talks/templates/wafer.talks/talk_withdraw.html
@@ -1,9 +1,5 @@
 {% extends 'wafer/base.html' %}
 {% load i18n %}
-{% load crispy_forms_tags %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <section class="wafer wafer-talk-withdrawal">
   <h1>{% trans "Confirm Talk Withdrawal" %}</h1>
@@ -18,7 +14,4 @@
     <input type="submit" class="btn btn-danger" value="{% trans 'Confirm Withdrawal' %}">
   </form>
 </section>
-{% endblock %}
-{% block extra_foot %}
-{{ form.media.js }}
 {% endblock %}

--- a/wafer/templates/markitup/editor.html
+++ b/wafer/templates/markitup/editor.html
@@ -1,0 +1,4 @@
+<div class="django-markitup-config" style="display: none"
+     data-element="#{{ textarea_id }}"
+     data-preview-url="{{ preview_url }}"
+     data-auto-preview="{{ AUTO_PREVIEW|yesno:"1,0" }}"></div>

--- a/wafer/templates/wafer/base_form.html
+++ b/wafer/templates/wafer/base_form.html
@@ -1,0 +1,12 @@
+{% extends "wafer/base.html" %}
+{% load i18n %}
+{% load crispy_forms_tags %}
+{% block extra_head %}
+  {{ form.media.css }}
+{% endblock %}
+{% block content %}
+  {% crispy form %}
+{% endblock %}
+{% block extra_foot %}
+  {{ form.media.js }}
+{% endblock %}

--- a/wafer/tickets/forms.py
+++ b/wafer/tickets/forms.py
@@ -14,6 +14,7 @@ class TicketForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(TicketForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
+        self.helper.include_media = False
         self.helper.add_input(Submit('submit', _('Claim')))
 
     def clean_barcode(self):

--- a/wafer/tickets/templates/wafer.tickets/claim.html
+++ b/wafer/tickets/templates/wafer.tickets/claim.html
@@ -1,9 +1,6 @@
-{% extends 'wafer/base.html' %}
+{% extends 'wafer/base_form.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 {% if not WAFER_REGISTRATION_OPEN %}
   {% trans "Ticket sales are not currently open" %}
@@ -26,7 +23,4 @@
     {% crispy form %}
   </section>
 {% endif %}
-{% endblock %}
-{% block extra_foot %}
-{{ form.media.js }}
 {% endblock %}

--- a/wafer/tickets/templates/wafer.tickets/claim.html
+++ b/wafer/tickets/templates/wafer.tickets/claim.html
@@ -1,6 +1,9 @@
 {% extends 'wafer/base.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 {% if not WAFER_REGISTRATION_OPEN %}
   {% trans "Ticket sales are not currently open" %}
@@ -23,4 +26,7 @@
     {% crispy form %}
   </section>
 {% endif %}
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/users/forms.py
+++ b/wafer/users/forms.py
@@ -14,6 +14,7 @@ class UserForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(UserForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
+        self.helper.include_media = False
         username = kwargs['instance'].username
         self.helper.form_action = reverse('wafer_user_edit',
                                           args=(username,))
@@ -31,6 +32,7 @@ class UserProfileForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(UserProfileForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
+        self.helper.include_media = False
         username = kwargs['instance'].user.username
         self.helper.form_action = reverse('wafer_user_edit_profile',
                                           args=(username,))

--- a/wafer/users/templates/wafer.users/edit_profile.html
+++ b/wafer/users/templates/wafer.users/edit_profile.html
@@ -1,13 +1,7 @@
-{% extends "wafer/base.html" %}
+{% extends "wafer/base_form.html" %}
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <h1>{% trans 'Edit Profile:' %}</h1>
 {% crispy form %}
-{% endblock %}
-{% block extra_foot %}
-{{ form.media.js }}
 {% endblock %}

--- a/wafer/users/templates/wafer.users/edit_profile.html
+++ b/wafer/users/templates/wafer.users/edit_profile.html
@@ -1,7 +1,13 @@
 {% extends "wafer/base.html" %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <h1>{% trans 'Edit Profile:' %}</h1>
 {% crispy form %}
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}

--- a/wafer/users/templates/wafer.users/edit_user.html
+++ b/wafer/users/templates/wafer.users/edit_user.html
@@ -1,9 +1,6 @@
-{% extends "wafer/base.html" %}
+{% extends "wafer/base_form.html" %}
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% block extra_head %}
-{{ form.media.css }}
-{% endblock %}
 {% block content %}
 <h1>{% trans 'Edit User:' %}</h1>
 {% if profile_user == user and profile_user.has_usable_password %}
@@ -16,7 +13,4 @@
   </ul>
 {% endif %}
 {% crispy form %}
-{% endblock %}
-{% block extra_foot %}
-{{ form.media.js }}
 {% endblock %}

--- a/wafer/users/templates/wafer.users/edit_user.html
+++ b/wafer/users/templates/wafer.users/edit_user.html
@@ -1,6 +1,9 @@
 {% extends "wafer/base.html" %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% block extra_head %}
+{{ form.media.css }}
+{% endblock %}
 {% block content %}
 <h1>{% trans 'Edit User:' %}</h1>
 {% if profile_user == user and profile_user.has_usable_password %}
@@ -13,4 +16,7 @@
   </ul>
 {% endif %}
 {% crispy form %}
+{% endblock %}
+{% block extra_foot %}
+{{ form.media.js }}
 {% endblock %}


### PR DESCRIPTION
I found a small herd of hairy yaks while looking at a JS error on our talk submission page:

> Uncaught TypeError: element.markItUp is not a function

The form was rendering inline script and CSS tags, that depended on JS that we were only loading at the end of the page.

Fixing some of this is fairly simple:
1. Pages with forms get slightly more complex, and are instructed to render CSS in the HEAD, and JS in the page foot.
1. Widgets are instructed to not load their own jQuery, because we provide one.

However, markitup renders inline JS that requires jQuery and markitup's JS library that defeats this strategy (zsiciarz/django-markitup#25) so I implemented a template override to work around it. I'll propose the same changes upstream.