### PR TITLE
The well is dry (more bootstrap4 migration)

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -1,4 +1,5 @@
 {% extends "wafer/base.html" %}
+{% load i18n %}
 {% load static from staticfiles %}
 {% block content %}
 <div class="row">
@@ -12,30 +13,20 @@
     {% endif %}
   </div>
   <div class="col-md-8">
-    <h1>Schedule Editor
-      <div class="float-right">
-        <ul class="nav nav-pills navbar-nav navbar-right">
-          <li role="presentation" class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown"
-               href="#" role="button" aria-haspopup="true"
-               aria-expanded="true">
-              {{ day.date }}
-              <span class="caret"></span>
-            </a>
-            <ul class="dropdown-menu"
-                aria-labelledby="dLabel">
-              {% for day in days %}
-                <li>
-                  <a href="{% url 'admin:schedule_editor' day.id %}">
-                    {{ day.date }} (Day {{ day.id }})
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </li>
-        </ul>
+    <div class="dropdown float-right">
+      <button class="btn btn-secondary dropdown-toggle" type="button"
+              data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        {{ day.date }} (Day {{ day.id }})
+      </button>
+      <div class="dropdown-menu">
+        {% for day in days %}
+          <a class="dropdown-item" href="{% url 'admin:schedule_editor' day.id %}">
+            {{ day.date }} (Day {{ day.id }})
+          </a>
+        {% endfor %}
       </div>
-    </h1>
+    </div>
+    <h1>{% trans "Schedule Editor" %}</h1>
     <table class="table table-sm">
       <thead>
         <tr>

--- a/wafer/schedule/templates/wafer.schedule/full_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/full_schedule.html
@@ -3,16 +3,16 @@
 {% block title %}{% trans "Schedule" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <section class="wafer wafer-schedule">
+  {% if user.is_authenticated and user.is_staff %}
+    <div class="float-right">
+      <a class="btn btn-secondary"
+          href="{% url 'admin:schedule_editor' %}">
+        Edit schedule
+      </a>
+    </div>
+  {% endif %}
   <h1>
     {% trans "Schedule" %}
-    {% if user.is_authenticated and user.is_staff %}
-      <div class="float-right">
-        <a class="btn btn-secondary"
-            href="{% url 'admin:schedule_editor' %}">
-          Edit schedule
-        </a>
-      </div>
-    {% endif %}
   </h1>
   <div class="wafer_schedule">
     {% if not schedule_days %}

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors.html
@@ -3,29 +3,32 @@
 {% block title %}{% trans "Sponsors" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <section class="wafer wafer-sponsors">
-<h1>{% trans 'Sponsors' %}</h1>
-<div class="wafer list">
+  <h1>{% trans 'Sponsors' %}</h1>
+  <div class="wafer list">
     {% for sponsor in sponsor_list %}
-    <section class="wafer wafer-sponsor">
-    <div class="well">
-      <h2 class="bs-callout bs-callout-default bs-callout-{{ sponsor.packages.first.name.lower }}">
-         {% if sponsor.symbol %}
-             {{ sponsor.symbol }}
-         {% endif %}
-         {% if sponsor.url %}
-         <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>
-         {% else %}
-         {{ sponsor.name }}
-         {% endif %}
-        <small class="text-right">{{ sponsor.packages.first.name }}</small>
-      </h2>
-      {{ sponsor.description.rendered|safe }}
-    </div>
-    <hr>
-    </section>
+      <section class="wafer wafer-sponsor
+                      wafer-sponsor-{{ sponsor.packages.first.name.lower }}">
+        <div class="card">
+          <div class="card-body">
+            <h2 class="card-title">
+             {% if sponsor.symbol %}
+               {{ sponsor.symbol }}
+             {% endif %}
+             {% if sponsor.url %}
+               <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>
+             {% else %}
+               {{ sponsor.name }}
+             {% endif %}
+             <small class="text-right">{{ sponsor.packages.first.name }}</small>
+            </h2>
+            {{ sponsor.description.rendered|safe }}
+          </div>
+        </div>
+        <hr>
+      </section>
     {% empty %}
-    <p>No sponsors yet.</p>
+      <p>No sponsors yet.</p>
     {% endfor %}
-</div>
+  </div>
 </section>
 {% endblock %}

--- a/wafer/static/css/wafer.css
+++ b/wafer/static/css/wafer.css
@@ -22,12 +22,6 @@
 	display: none;
 }
 
-.profile-links li{
-	list-style: none;
-	display: inline-block;
-	margin-left: 5px;
-}
-
 [draggable] {
 	-moz-user-select: none;
 	-khtml-user-select: none;
@@ -45,99 +39,6 @@
 
 .droppable.over{
     border: 5px dashed #000;
-}
-
-.bs-callout {
-    padding: 5px;
-    margin: 20px 0;
-    border: 1px solid #eee;
-    border-left-width: 10px;
-    border-radius: 6px;
-}
-
-.bs-callout h4 {
-    margin-top: 0;
-    margin-bottom: 5px;
-}
-
-.bs-callout p:last-child {
-    margin-bottom: 0;
-}
-
-.bs-callout code {
-    border-radius: 3px;
-}
-
-.bs-callout+.bs-callout {
-    margin-top: -5px;
-}
-
-.bs-callout-default {
-    border-left-color: #777;
-}
-
-.bs-callout-default h4 {
-    color: #777;
-}
-
-.bs-callout-primary {
-    border-left-color: #428bca;
-}
-
-.bs-callout-primary h4 {
-    color: #428bca;
-}
-
-.bs-callout-success {
-    border-left-color: #5cb85c;
-}
-
-.bs-callout-success h4 {
-    color: #5cb85c;
-}
-
-.bs-callout-danger {
-    border-left-color: #d9534f;
-}
-
-.bs-callout-danger h4 {
-    color: #d9534f;
-}
-
-.bs-callout-warning {
-    border-left-color: #f0ad4e;
-}
-
-.bs-callout-warning h4 {
-    color: #f0ad4e;
-}
-
-.bs-callout-info {
-    border-left-color: #5bc0de;
-}
-
-.bs-callout-info h4 {
-    color: #5bc0de;
-}
-
-.bs-callout-platinum {
-    border-left-color: #E5E4E2;
-}
-
-.bs-callout-gold {
-    border-left-color: #DAA520;
-}
-
-.bs-callout-silver {
-    border-left-color: #C0C0C0;
-}
-
-.bs-callout-bronze {
-    border-left-color: #CD7F32;
-}
-
-.bs-callout-patron {
-    border-left-color: #A4C639;
 }
 
 /* Temporary workaronud for Bootstrap4 alpha 6

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -82,22 +82,34 @@
   </div>
   {% if perms.talks.view_all_talks or user.is_superuser %}
     {% if talk.notes %}
-      {% blocktrans %}
-        <h2>Talk Notes</h2>
-        <p>(The following is not visible to attendees.)</p>
-      {% endblocktrans %}
-      <div id="notes">
-        {{ object.notes|urlize|linebreaks }}
+      <div id="notes" class="card mb-3">
+        <div class="card-header">
+          {% blocktrans %}
+            <h2>Talk Notes</h2>
+            <p>(The following is not visible to attendees.)</p>
+          {% endblocktrans %}
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            {{ object.notes|urlize|linebreaksbr }}
+          </p>
+        </div>
       </div>
     {% endif %}
   {% endif %}
   {% if perms.talks.edit_private_notes and object.private_notes %}
-    {% blocktrans %}
-      <h2>Private notes</h2>
-      <p>(The following is not visible to submitters or attendees.)</p>
-    {% endblocktrans %}
-    <div id="private_notes">
-      {{ object.private_notes|urlize|linebreaks }}
+    <div id="private_notes" class="card mb-3">
+      <div class="card-header">
+        {% blocktrans %}
+          <h2>Private notes</h2>
+          <p>(The following is not visible to submitters or attendees.)</p>
+        {% endblocktrans %}
+      </div>
+      <div class="card-body">
+        <p class="card-text">
+          {{ object.private_notes|urlize|linebreaksbr }}
+        </p>
+      </div>
     </div>
   {% endif %}
   {% if talk.talkurl_set.all %}

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -77,7 +77,7 @@
       </p>
     </div>
   {% endif %}
-  <div class="well">
+  <div id="abstract">
     {{ object.abstract.rendered|safe }}
   </div>
   {% if perms.talks.view_all_talks or user.is_superuser %}
@@ -86,7 +86,7 @@
         <h2>Talk Notes</h2>
         <p>(The following is not visible to attendees.)</p>
       {% endblocktrans %}
-      <div class="well">
+      <div id="notes">
         {{ object.notes|urlize|linebreaks }}
       </div>
     {% endif %}
@@ -96,19 +96,17 @@
       <h2>Private notes</h2>
       <p>(The following is not visible to submitters or attendees.)</p>
     {% endblocktrans %}
-    <div class="well">
+    <div id="private_notes">
       {{ object.private_notes|urlize|linebreaks }}
     </div>
   {% endif %}
   {% if talk.talkurl_set.all %}
-    <div class="well" id="urls">
-    <div>{% trans "URLS" %}</div>
-    <ul>
+    <h3 id="urls_title">{% trans "URLs" %}</h3>
+    <ul class="list-group" id="urls">
       {% for talkurl in talk.talkurl_set.all %}
-        <li><a href="{{ talkurl.url }}">{{ talkurl.description }}</a></li>
+        <li class="list-group-item"><a href="{{ talkurl.url }}">{{ talkurl.description }}</a></li>
       {% endfor %}
     </ul>
-  </div>
   {% endif %}
 </section>
 {% endblock %}

--- a/wafer/templates/wafer/base.html
+++ b/wafer/templates/wafer/base.html
@@ -3,38 +3,39 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{% block title %}{{ WAFER_CONFERENCE_NAME }}{% endblock %}</title>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet" media="screen">
-    <link href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet" media="screen">
-    <link href="{% static 'css/wafer.css' %}" rel="stylesheet" media="screen">
-    {% block extra_head %}{% endblock %}
+  <title>{% block title %}{{ WAFER_CONFERENCE_NAME }}{% endblock %}</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet" media="screen">
+  <link href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet" media="screen">
+  <link href="{% static 'css/wafer.css' %}" rel="stylesheet" media="screen">
+  {% block extra_head %}{% endblock %}
 </head>
 <body>
-    {% include "wafer/nav.html" %}
-    <div id="main" class="container">
-        {% if messages %}
-        <div class="messages">
-            {% for message in messages %}
-            <div class="alert
-                {% if message.tags == 'error' %}
-                    alert-danger
-                {% elif message.tags %}
-                    alert-{{ message.tags }}
-                {% endif %}">{{ message }}</div>
-            {% endfor %}
-        </div>
-        {% endif %}
-{% block content %}
-    <h1>{{ WAFER_CONFERENCE_NAME }}</h1>
-{% endblock %}
-    </div>
-    {% sponsors %}
-    <script src="{% static 'vendor/jquery/dist/jquery.min.js' %}"></script>
-    <script src="{% static 'vendor/popper.js/dist/umd/popper.min.js' %}"></script>
-    <script src="{% static 'vendor/bootstrap/dist/js/bootstrap.min.js' %}"></script>
-    {% block extra_foot %}{% endblock %}
+  {% include "wafer/nav.html" %}
+  <div id="main" class="container {% block container_class %}{% endblock %}">
+    {% if messages %}
+      <div class="messages">
+        {% for message in messages %}
+          <div class="alert
+            {% if message.tags == 'error' %}
+                      alert-danger
+            {% elif message.tags %}
+                      alert-{{ message.tags }}
+            {% endif %}">{{ message }}
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+    {% block content %}
+      <h1>{{ WAFER_CONFERENCE_NAME }}</h1>
+    {% endblock %}
+  </div>
+  {% sponsors %}
+  <script src="{% static 'vendor/jquery/dist/jquery.min.js' %}"></script>
+  <script src="{% static 'vendor/popper.js/dist/umd/popper.min.js' %}"></script>
+  <script src="{% static 'vendor/bootstrap/dist/js/bootstrap.min.js' %}"></script>
+  {% block extra_foot %}{% endblock %}
 </body>
 </html>

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -33,7 +33,7 @@
           <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">
             {{ item.label }}
           </a>
-          <ul class="dropdown-menu dropdown-menu-right">
+          <ul class="dropdown-menu">
             {% for subitem in item.items %}
             <li><a class="dropdown-item" href="{{ subitem.url }}">
                 {{ subitem.label }}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -1,6 +1,7 @@
 {% extends "wafer/base.html" %}
 {% load i18n %}
 {% block title %}{{ object.userprofile.display_name }} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
+{% block container_class %}userprofile{% endblock %}
 {% block content %}
 <section class="wafer wafer-profile">
   {% with profile=object.userprofile %}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -5,162 +5,188 @@
 {% block content %}
 <section class="wafer wafer-profile">
   {% with profile=object.userprofile %}
-  <div class="row">
+    <div class="row">
       <div class="col-md-2" id="profile-avatar">
-          {% with profile.avatar_url as avatar_url %}
-              {% if avatar_url != None %}
-              <img src="{{ profile.avatar_url }}">
-              {% endif %}
-          {% endwith %}
-          {% if can_edit %}
-              <a class="btn btn-secondary btn-sm" href="#" rel="popover" data-toggle="popover"
-                  data-title="{% trans 'Changing your mugshot' %}" data-html="true"
-                  data-placement="bottom">{% trans 'Edit Mugshot' %}</a>
-              <div class="popover-contents">
-                  {% blocktrans %}
-                      Pictures provided by <a href="https://www.libravatar.org/">libravatar</a>
-                      (which falls back to <a href="https://secure.gravatar.com/">Gravatar</a>).<br>
-                      Change your picture there.
-                  {% endblocktrans %}
-              </div>
+        {% with profile.avatar_url as avatar_url %}
+          {% if avatar_url != None %}
+            <img src="{{ profile.avatar_url }}">
           {% endif %}
+        {% endwith %}
+        {% if can_edit %}
+          <a class="btn btn-secondary btn-sm" href="#" rel="popover" data-toggle="popover"
+              data-title="{% trans 'Changing your mugshot' %}" data-html="true"
+              data-placement="bottom">{% trans 'Edit Mugshot' %}</a>
+          <div class="popover-contents">
+            {% blocktrans %}
+              Pictures provided by <a href="https://www.libravatar.org/">libravatar</a>
+              (which falls back to <a href="https://secure.gravatar.com/">Gravatar</a>).<br>
+              Change your picture there.
+            {% endblocktrans %}
+          </div>
+        {% endif %}
       </div>
       <div class="col-md-10">
-          {% if can_edit %}
+        {% if can_edit %}
           <ul class="float-right btn-group btn-group-vertical profile-links">
-              <li><a href="{% url 'wafer_user_edit' object.username %}" class="btn btn-secondary">{% trans 'Edit User' %}</a></li>
-              <li><a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn btn-secondary">{% trans 'Edit Profile' %}</a></li>
-              {% if WAFER_REGISTRATION_OPEN and not profile.is_registered %}
-                  {% if WAFER_REGISTRATION_MODE == 'ticket' %}
-                      {% url 'wafer_ticket_claim' as register_url %}
-                  {% endif %}
-                  {% if register_url %}
-                      <li><a href="{{ register_url }}" class="btn btn-secondary">{% trans 'Register' %}</a></li>
-                  {% endif %}
+            <li><a href="{% url 'wafer_user_edit' object.username %}" class="btn btn-secondary">{% trans 'Edit User' %}</a></li>
+            <li><a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn btn-secondary">{% trans 'Edit Profile' %}</a></li>
+            {% if WAFER_REGISTRATION_OPEN and not profile.is_registered %}
+              {% if WAFER_REGISTRATION_MODE == 'ticket' %}
+                {% url 'wafer_ticket_claim' as register_url %}
               {% endif %}
-              <li><a href="{% url 'wafer_talk_submit' %}" class="btn btn-secondary">{% trans 'Submit Talk Proposal' %}</a></li>
+              {% if register_url %}
+                <li><a href="{{ register_url }}" class="btn btn-secondary">{% trans 'Register' %}</a></li>
+              {% endif %}
+            {% endif %}
+            <li><a href="{% url 'wafer_talk_submit' %}" class="btn btn-secondary">{% trans 'Submit Talk Proposal' %}</a></li>
           </ul>
+        {% endif %}
+        {% spaceless %}
+        <h1>
+          {% if profile.homepage %}
+            <a href="{{ profile.homepage_url }}">
           {% endif %}
-          {% spaceless %}
-          <h1>
-              {% if profile.homepage %}
-                  <a href="{{ profile.homepage_url }}">
-              {% endif %}
-              {{ profile.display_name }}
-              {% if profile.homepage %}
-                  </a>
-              {% endif %}
-          </h1>
-          {% if profile.twitter_handle %}
+          {{ profile.display_name }}
+          {% if profile.homepage %}
+            </a>
+          {% endif %}
+        </h1>
+        {% if profile.twitter_handle %}
           <p>
-              <a href="https://twitter.com/{{ profile.twitter_handle }}" class="twitter-follow-button" data-show-count="false">
-                  {% blocktrans with handle=profile.twitter_handle %}Follow @{{ handle }}{% endblocktrans %}
-              </a>
+            <a href="https://twitter.com/{{ profile.twitter_handle }}" class="twitter-follow-button" data-show-count="false">
+              {% blocktrans with handle=profile.twitter_handle %}Follow @{{ handle }}{% endblocktrans %}
+            </a>
           </p>
-          {% endif %}
-          {% if profile.github_username %}
+        {% endif %}
+        {% if profile.github_username %}
           <p>
-              <a href="https://github.com/{{ profile.github_username }}">
-                  {% blocktrans with username=profile.github_username %}GitHub: {{ username }}{% endblocktrans %}
-              </a>
+            <a href="https://github.com/{{ profile.github_username }}">
+              {% blocktrans with username=profile.github_username %}GitHub: {{ username }}{% endblocktrans %}
+            </a>
           </p>
-          {% endif %}
-          {% endspaceless %}
+        {% endif %}
+        {% endspaceless %}
       </div>
-  </div>
-  {% if profile.bio %}
-  <div class="well">
-  {{ profile.bio|linebreaks }}
-  </div>
-  {% endif %}
-  {% if can_edit %}
+    </div>
+    {% if profile.bio %}
+      <div class="bio">
+        {{ profile.bio|linebreaks }}
+      </div>
+    {% endif %}
+    {% if can_edit %}
       {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
-          {% if profile.is_registered %}
-              <div class="alert alert-success">
-                  {% blocktrans %}
-                      Registered
-                  {% endblocktrans %}
-              </div>
-          {% else %}
-              <div class="alert alert-danger">
-                  {% blocktrans %}
-                      <strong>WARNING:</strong>
-                      Talk proposal submitted, but not registered.
-                  {% endblocktrans %}
-                  {% if WAFER_REGISTRATION_OPEN %}
-                      {% trans "Register now!" %}
-                  {% endif %}
-              </div>
-          {% endif %}
+        {% if profile.is_registered %}
+          <div class="alert alert-success">
+            {% blocktrans %}
+              Registered
+            {% endblocktrans %}
+          </div>
+        {% else %}
+          <div class="alert alert-danger">
+            {% blocktrans %}
+              <strong>WARNING:</strong>
+              Talk proposal submitted, but not registered.
+            {% endblocktrans %}
+            {% if WAFER_REGISTRATION_OPEN %}
+              {% trans "Register now!" %}
+            {% endif %}
+          </div>
+        {% endif %}
       {% endif %}
-  {% endif %}
-  {# Accepted talks are globally visible #}
-  {% if profile.accepted_talks.exists %}
-  <h2>{% trans 'Accepted Talks:' %}</h2>
-  {% for talk in profile.accepted_talks %}
-  <div class="well">
-      <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
-      <p>{{ talk.abstract.rendered|safe }}</p>
-  </div>
-  {% endfor %}
-  {% endif %}
-  {% if profile.cancelled_talks.exists %}
-  <h2>{% trans 'Cancelled Talks:' %}</h2>
-  {% for talk in profile.cancelled_talks %}
-  <div class="well">
-      <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
-      <p>{{ talk.abstract.rendered|safe }}</p>
-  </div>
-  {% endfor %}
-  {% endif %}
-  {% if profile.provisional_talks.exists %}
-  <h2>{% trans 'Provisionally Accepted Talks:' %}</h2>
-  {% for talk in profile.provisional_talks %}
-  <div class="well">
-      <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
-      <p>{{ talk.abstract.rendered|safe }}</p>
-  </div>
-  {% endfor %}
-  {% endif %}
-
-  {# Submitted talk proposals are only visible to the owner #}
-  {% if can_edit %}
-  {% if profile.pending_talks.exists %}
-  <h2>{% trans 'Submitted or Under Consideration Talks:' %}</h2>
-  {% for talk in profile.pending_talks %}
-  <div class="well">
-      <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
-      {% comment %}
-      Because this is one of the author's pending talks, we don't need to
-      check for edit permission's on the talk explictly. This doesn't show
-      the edit button for people with 'change-talk' permissions, but we
-      accept that tradeoff for simplicity here.
-      {% endcomment %}
-      <a href="{% url 'wafer_talk_edit' talk.pk %}" class="float-right btn btn-secondary btn-lg">{% trans 'Edit' %}</a>
-      <p>{{ talk.abstract.rendered|safe }}</p>
-  </div>
-  {% endfor %}
-  {% endif %}
-  {% endif %}
+    {% endif %}
+    {# Accepted talks are globally visible #}
+    {% if profile.accepted_talks.exists %}
+      <h2>{% trans 'Accepted Talks:' %}</h2>
+      {% for talk in profile.accepted_talks %}
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title">
+              <a href="{{ talk.get_absolute_url }}">
+                {{ talk.title }}
+              </a>
+            </h3>
+            <p>{{ talk.abstract.rendered|safe }}</p>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
+    {% if profile.cancelled_talks.exists %}
+      <h2>{% trans 'Cancelled Talks:' %}</h2>
+      {% for talk in profile.cancelled_talks %}
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title">
+              <a href="{{ talk.get_absolute_url }}">
+                {{ talk.title }}
+              </a>
+            </h3>
+            <p>{{ talk.abstract.rendered|safe }}</p>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
+    {% if profile.provisional_talks.exists %}
+      <h2>{% trans 'Provisionally Accepted Talks:' %}</h2>
+      {% for talk in profile.provisional_talks %}
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title">
+              <a href="{{ talk.get_absolute_url }}">
+                {{ talk.title }}
+              </a>
+            </h3>
+            <p>{{ talk.abstract.rendered|safe }}</p>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
+    {# Submitted talk proposals are only visible to the owner #}
+    {% if can_edit %}
+      {% if profile.pending_talks.exists %}
+        <h2>{% trans 'Submitted or Under Consideration Talks:' %}</h2>
+        {% for talk in profile.pending_talks %}
+          <div class="card">
+            <div class="card-body">
+              {% comment %}
+                Because this is one of the author's pending talks, we don't
+                need to check for edit permission's on the talk explictly.
+                This doesn't show the edit button for people with 'change-talk'
+                permissions, but we accept that tradeoff for simplicity here.
+              {% endcomment %}
+              <a href="{% url 'wafer_talk_edit' talk.pk %}"
+                 class="float-right btn btn-secondary btn-lg">
+                {% trans 'Edit' %}
+              </a>
+              <h3 class="card-title">
+                <a href="{{ talk.get_absolute_url }}">
+                  {{ talk.title }}
+                </a>
+              </h3>
+              <p>{{ talk.abstract.rendered|safe }}</p>
+            </div>
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endif %}
   {% endwith %}
 </section>
 {% endblock %}
 {% block extra_foot %}
-    <script type="text/javascript">
-        {% if profile.twitter_handle %}
-        // Twitter boilerplate
-        !function(d, s, id) {
-            var js, fjs = d.getElementsByTagName(s)[0];
-            if (! d.getElementById(id)) {
-                js = d.createElement(s);
-                js.id = id;
-                js.src = "//platform.twitter.com/widgets.js";
-                fjs.parentNode.insertBefore(js, fjs);
-            }
-        }(document, "script", "twitter-wjs");
-        {% endif %}
+<script type="text/javascript">
+  {% if profile.twitter_handle %}
+    // Twitter boilerplate
+    !function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (! d.getElementById(id)) {
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "//platform.twitter.com/widgets.js";
+        fjs.parentNode.insertBefore(js, fjs);
+      }
+    }(document, "script", "twitter-wjs");
+  {% endif %}
 
-        $("#profile-avatar [rel=popover]").attr("data-content", $("#profile-avatar .popover-contents").html());
-        $("a[rel=popover]").popover();
-    </script>
+  $("#profile-avatar [rel=popover]").attr("data-content", $("#profile-avatar .popover-contents").html());
+  $("a[rel=popover]").popover();
+</script>
 {% endblock %}

--- a/wafer/users/templates/wafer.users/users.html
+++ b/wafer/users/templates/wafer.users/users.html
@@ -3,30 +3,32 @@
 {% block title %}{% trans "Users" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <h1>{% trans 'Users:' %}</h1>
-{% for user in user_list %}
-<a href="{% url 'wafer_user_profile' username=user.username %}">
-    <div class="well">
+<ul class="list-group">
+  {% for user in user_list %}
+    <a href="{% url 'wafer_user_profile' username=user.username %}">
+      <li class="list-group-item">
         {{ user.userprofile.display_name }}
-    </div>
-</a>
-{% endfor %}
+      </li>
+    </a>
+  {% endfor %}
+</ul>
 {% if is_paginated %}
-<section class="wafer wafer-pagination">
+  <section class="wafer wafer-pagination">
     <ul class="pagination">
-        {% if page_obj.has_previous %}
+      {% if page_obj.has_previous %}
         <li class="page-item"><a class="page-link" href="{% url 'wafer_users_page' page=page_obj.previous_page_number %}">&laquo;</a></li>
-        {% else %}
+      {% else %}
         <li class="disabled"><a class="page-link" href="#">&laquo;</a></li>
-        {% endif %}
-        {% for page in paginator.page_range %}
+      {% endif %}
+      {% for page in paginator.page_range %}
         <li class="page-item"><a class="page-link" href="{% url 'wafer_users_page' page=page %}">{{ page }}</a></li>
-        {% endfor %}
-        {% if page_obj.has_next %}
+      {% endfor %}
+      {% if page_obj.has_next %}
         <li class="page-item"><a class="page-link" href="{% url 'wafer_users_page' page=page_obj.next_page_number %}">&raquo;</a></li>
-        {% else %}
+      {% else %}
         <li class="disabled"><a class="page-link" href="#">&raquo;</a></li>
-        {% endif %}
+      {% endif %}
     </ul>
-</section>
+  </section>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
There were a few leftover clasess from bootstrap 3 that we never stopped using after bootstrap 4 dropped them.

* [well][]s are largely replaced by [card][]s.
* `bs-callout` was something we copied from Bootstrap3 documentation, but it didn't really fit into cards.

[well]: https://getbootstrap.com/docs/3.3/components/#wells
[card]: https://getbootstrap.com/docs/4.0/components/card/

I've tried to tag objects with classes, so that consumers of wafer can style the elements to suit their site. There are probably more places that we need to do this...

Unfortunately, there's a lot of whitespace change involved. I tried to tidy indentation while I was there, but the diff is going to be hard to read.