### PR TITLE
As of 0.6.0 we support 1.11 and 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,5 @@ install:
    # Install the right version of Django first
    - pip install "$DJANGO"
    - pip install -r requirements.txt -r requirements-dev.txt
-   # For Django 1.8 & Django 1.9, we need to downgrade djangorestframework
-   # This goes away when we drop support for Django 1.8 & 1.9
-   - |
-     if [ "$DJANGO" = 'django>=1.8.0,<1.9.0' -o "$DJANGO" = 'django>=1.9.0,<1.10.0' ]; then
-           pip install -U  'djangorestframework<3.7'
-       fi
 # command to run tests
 script: NOSE_WITH_COVERAGE=1 python manage.py test

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Available on `readthedocs.org`_.
 Supported Django versions
 =========================
 
-Wafer supports Django 1.8 and Django 1.9.
+Wafer supports Django 1.11 and Django 2.0.
 
 
 Installation
@@ -38,10 +38,6 @@ Installation
 
 1. ``pip install -r requirements.txt`` should install all the required
    python and django dependencies.
-
-   If you're using Django 1.8 or 1.9, you will need to downgrade
-   djangorestframework to the 3.6 series, since djangorestframework 3.7
-   does not support those versions.
 
 2. Wafer uses npm to manage front-end dependencies
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Supported versions
 ==================
 
-Wafer supports Django 1.8-1.11 and Python 2.7, 3.4-3.6.
+Wafer supports Django 1.11-2.0 and Python 2.7, 3.4-3.6.
 
 Requirements
 ============

--- a/wafer/utils.py
+++ b/wafer/utils.py
@@ -34,8 +34,6 @@ def cache_result(cache_key, timeout):
 
         @functools.wraps(f)
         def wrapper(*args, **kw):
-            # replace this with cache.caches when we drop Django 1.6
-            # compatibility
             cache = caches[cache_name]
             result = cache.get(cache_key)
             if result is None:


### PR DESCRIPTION
We forgot to update the docs.