### PR TITLE
Reword "speaker hasn't registered" message

### DIFF
--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -85,7 +85,7 @@
           <div class="alert alert-danger">
             {% blocktrans %}
               <strong>WARNING:</strong>
-              Talk proposal submitted, but not registered.
+              Talk proposal submitted, but speaker hasn't registered to attend.
             {% endblocktrans %}
             {% if WAFER_REGISTRATION_OPEN %}
               {% trans "Register now!" %}


### PR DESCRIPTION
It's ambiguous to people who don't know wafer's data model.

See: https://salsa.debian.org/debconf-team/public/websites/dc18/issues/38