### PR TITLE
Use django-registration's backend URLs

### DIFF
--- a/wafer/registration/urls.py
+++ b/wafer/registration/urls.py
@@ -1,7 +1,4 @@
 from django.conf.urls import include, url
-from django.views.generic import TemplateView
-
-from registration.backends.default.views import ActivationView, RegistrationView
 
 from wafer.registration.views import debian_login, github_login, redirect_profile
 
@@ -12,27 +9,6 @@ urlpatterns = [
     url(r'^github-login/$', github_login),
     url(r'^debian-login/$', debian_login),
 
-    # registration.backends.default.urls, but Django 1.5 compatible
-    url(r'^activate/complete/$',
-        TemplateView.as_view(
-            template_name='registration/activation_complete.html'
-        ), name='registration_activation_complete'),
-    url(r'^activate/(?P<activation_key>\w+)/$',
-        ActivationView.as_view(
-            template_name='registration/activate.html'
-        ), name='registration_activate'),
-    url(r'^register/$',
-        RegistrationView.as_view(
-            template_name='registration/registration_form.html'
-        ),
-        name='registration_register'),
-    url(r'^register/complete/$',
-        TemplateView.as_view(
-            template_name='registration/registration_complete.html'
-        ), name='registration_complete'),
-    url(r'^register/closed/$',
-        TemplateView.as_view(
-            template_name='registration/registration_closed.html'
-        ), name='registration_disallowed'),
+    url(r'', include('registration.backends.default.urls')),
     url(r'', include('registration.auth_urls')),
 ]


### PR DESCRIPTION
django-registration has supported Django 1.5 for about 5 years now. There's no need to re-implement this ourselves.

Plus, we can get some new features like /accounts/activate/resend/