### PR TITLE
Add templates to show talk types and tracks and their descriptions.

### DIFF
--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -28,6 +28,11 @@ admin interface. Both the global ``WAFER_TALKS_OPEN`` setting and the individual
 ``Talk Type`` must be set to allow submissions for submissions of the given
 type to be accepted.
 
+There is a Django view at ``/talks/types`` which displays the list of
+types and their descriptions. By default, this list isn't linked to the menu,
+since it's intended to be linked to by pages describing the talks and talk
+submission process.
+
 Submitting Talks
 ================
 
@@ -99,6 +104,11 @@ the option will be hidden from the submitter.
 
 Currently, tracks merely provide extra information for talk reviewers and
 attendees.
+
+There is a Django view at ``/talks/tracks`` which displays the list of
+tracks and their descriptions. As with talk types, this list isn't linked to
+the menu, since it's intended to be linked to by pages describing the talks and
+talk submission process.
 
 Talk urls
 =========

--- a/wafer/talks/templates/wafer.talks/talk_tracks.html
+++ b/wafer/talks/templates/wafer.talks/talk_tracks.html
@@ -4,11 +4,15 @@
 {% block content %}
 <section class="wafer wafer-talk-tracks">
   <h1>{% trans 'Tracks' %}</h1>
+    {% if object_list.count > 0 %}
     <dl class="track-list">
     {% for track in object_list %}
       <dt class="track-name">{{ track.name }}</dt>
       <dd class="track-description">{{ track.description }}</dt>
     {% endfor %}
     </dl>
+    {% else %}
+    <p>No tracks defined.</p>
+    {% endif %}
 </section>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_tracks.html
+++ b/wafer/talks/templates/wafer.talks/talk_tracks.html
@@ -1,0 +1,15 @@
+{% extends "wafer/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Tracks" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
+{% block content %}
+<section class="wafer wafer-talk-tracks">
+  <h1>{% trans 'Tracks' %}</h1>
+    <ul class="track-list">
+    {% for track in object_list %}
+       <li>{{ track.name }} &mdash; {{ track.description }}</li>
+    {% empty %}
+       <li>No Talk Tracks specified for this conference</li>
+    {% endfor %}
+    </ul>
+</section>
+{% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_tracks.html
+++ b/wafer/talks/templates/wafer.talks/talk_tracks.html
@@ -4,12 +4,11 @@
 {% block content %}
 <section class="wafer wafer-talk-tracks">
   <h1>{% trans 'Tracks' %}</h1>
-    <ul class="track-list">
+    <dl class="track-list">
     {% for track in object_list %}
-       <li>{{ track.name }} &mdash; {{ track.description }}</li>
-    {% empty %}
-       <li>No Talk Tracks specified for this conference</li>
+      <dt class="track-name">{{ track.name }}</dt>
+      <dd class="track-description">{{ track.description }}</dt>
     {% endfor %}
-    </ul>
+    </dl>
 </section>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_types.html
+++ b/wafer/talks/templates/wafer.talks/talk_types.html
@@ -4,10 +4,11 @@
 {% block content %}
 <section class="wafer wafer-talk-types">
   <h1>{% trans 'Talk Types' %}</h1>
-    <ul class="talk-type-list">
+    <dl class="talk-type-list">
     {% for type in object_list %}
-        <li>{{ type.name }} &mdash; {{ type.description }}</li>
+      <dt class="talk-type-name">{{ type.name }}</dt>
+      <dd class="talk-type-description">{{ type.description }}</dd>
     {% endfor %}
-    </ul>
+    </dl>
 </section>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_types.html
+++ b/wafer/talks/templates/wafer.talks/talk_types.html
@@ -1,0 +1,13 @@
+{% extends "wafer/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Talk Types" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
+{% block content %}
+<section class="wafer wafer-talk-types">
+  <h1>{% trans 'Talk Types' %}</h1>
+    <ul class="talk-type-list">
+    {% for type in object_list %}
+        <li>{{ type.name }} &mdash; {{ type.description }}</li>
+    {% endfor %}
+    </ul>
+</section>
+{% endblock %}

--- a/wafer/talks/templates/wafer.talks/talk_types.html
+++ b/wafer/talks/templates/wafer.talks/talk_types.html
@@ -4,11 +4,15 @@
 {% block content %}
 <section class="wafer wafer-talk-types">
   <h1>{% trans 'Talk Types' %}</h1>
+    {% if object_list.count > 0 %}
     <dl class="talk-type-list">
     {% for type in object_list %}
       <dt class="talk-type-name">{{ type.name }}</dt>
       <dd class="talk-type-description">{{ type.description }}</dd>
     {% endfor %}
     </dl>
+    {% else %}
+    <p>No talk types defined.</p>
+    {% endif %}
 </section>
 {% endblock %}

--- a/wafer/talks/urls.py
+++ b/wafer/talks/urls.py
@@ -3,7 +3,7 @@ from rest_framework_extensions import routers
 
 from wafer.talks.views import (
     Speakers, TalkCreate, TalkWithdraw, TalkUpdate, TalkView, UsersTalks,
-    TalksViewSet, TalkUrlsViewSet)
+    TalkTypesView, TracksView, TalksViewSet, TalkUrlsViewSet)
 
 router = routers.ExtendedSimpleRouter()
 
@@ -23,5 +23,7 @@ urlpatterns = [
     url(r'^(?P<pk>\d+)/withdraw/$', TalkWithdraw.as_view(),
         name='wafer_talk_withdraw'),
     url(r'^speakers/$', Speakers.as_view(), name='wafer_talks_speakers'),
+    url(r'^tracks/', TracksView.as_view(), name='wafer_talk_tracks'),
+    url(r'^types/', TalkTypesView.as_view(), name='wafer_talk_types'),
     url(r'^api/', include(router.urls)),
 ]

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -16,8 +16,8 @@ from rest_framework.permissions import (
 from rest_framework_extensions.mixins import NestedViewSetMixin
 from reversion import revisions
 
-from wafer.talks.models import (Talk, TalkType, TalkUrl, ACCEPTED, CANCELLED,
-                                WITHDRAWN)
+from wafer.talks.models import (Talk, TalkType, TalkUrl, Track, ACCEPTED,
+                                CANCELLED, WITHDRAWN)
 from wafer.talks.forms import get_talk_form_class
 from wafer.talks.serializers import TalkSerializer, TalkUrlSerializer
 from wafer.users.models import UserProfile
@@ -163,6 +163,16 @@ class Speakers(ListView):
                 'user').order_by('user__first_name', 'user__last_name')
         context["speaker_rows"] = self._by_row(speakers, 4)
         return context
+
+
+class TracksView(ListView):
+    model = Track
+    template_name = 'wafer.talks/talk_tracks.html'
+
+
+class TalkTypesView(ListView):
+    model = TalkType
+    template_name = 'wafer.talks/talk_types.html'
 
 
 class TalksViewSet(viewsets.ModelViewSet, NestedViewSetMixin):


### PR DESCRIPTION
So we can link to them elsewhere, such as a "how to submit a talk" page or the like.