### PR TITLE
Add more filters for slots and schedule items in the admin view

### DIFF
--- a/wafer/schedule/tests/test_admin.py
+++ b/wafer/schedule/tests/test_admin.py
@@ -227,7 +227,7 @@ class SlotListFilterTest(TestCase):
 
     def test_queryset_day_time(self):
         """Test queries with slots created purely by day + start_time"""
-        slots ={}
+        slots = {}
         slots[self.day1] = [Slot(day=self.day1, start_time=D.time(11, 0, 0),
                     end_time=D.time(12, 00, 0))]
         slots[self.day2] = [Slot(day=self.day2, start_time=D.time(11, 0, 0),


### PR DESCRIPTION
This adds some f filters to the schedule admin site, to make finding particular slots and schedule items easier.