### PR TITLE
Don't include the navbar in printouts

### DIFF
--- a/wafer/templates/wafer/base.html
+++ b/wafer/templates/wafer/base.html
@@ -7,9 +7,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet" media="screen">
-  <link href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet" media="screen">
-  <link href="{% static 'css/wafer.css' %}" rel="stylesheet" media="screen">
+  <link href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet">
+  <link href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet">
+  <link href="{% static 'css/wafer.css' %}" rel="stylesheet">
   {% block extra_head %}{% endblock %}
 </head>
 <body>

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<nav class="navbar navbar-expand-sm navbar-dark bg-dark {{ WAFER_NAVIGATION_VISIBILITY }}">
+<nav class="navbar navbar-expand-sm navbar-dark bg-dark d-print-none {{ WAFER_NAVIGATION_VISIBILITY }}">
   <div class="container">
     {% block navtogglebutton %}
       <button type="button" class="navbar-toggler navbar-toggler-right"


### PR DESCRIPTION
In the DebConf website, this has been sufficient for reasonable printing:

```scss
@media print {
  nav.navbar {
    display: none;
  }

  .footer {
    display: none;
  }
}
```

wafer's default template includes no footer, so this should be equivalent.

Fixes: #141 