### PR TITLE
Change review values to be 0-centered (-2..2)

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -91,6 +91,10 @@ Wafer's settings
     When ``True``, users can register for the conference.
     (Note, this is not the same as signing up for an account on the website.)
 
+``WAFER_TALK_REVIEW_SCORES``
+    A tuple of 2 integers.
+    The range of values for talk reviews. Inclusive.
+
 ``WAFER_TALKS_OPEN``
     A boolean flag.
     When ``True``, users can submit talks.

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -279,6 +279,9 @@ WAFER_TALK_FORM = 'wafer.talks.forms.TalkForm'
 WAFER_VIDEO = True
 WAFER_VIDEO_REVIEWER = True
 
+# Range of scores for talk reviews (inclusive)
+WAFER_TALK_REVIEW_SCORES = (-2, 2)
+
 # Set this to False to disable registration
 WAFER_REGISTRATION_OPEN = True
 

--- a/wafer/talks/admin.py
+++ b/wafer/talks/admin.py
@@ -49,7 +49,7 @@ class TalkUrlInline(admin.TabularInline):
 
 class ReviewInline(admin.TabularInline):
     model = Review
-    readonly_fields = ('reviewer', 'notes', 'total_score', 'scores')
+    readonly_fields = ('reviewer', 'notes', 'avg_score', 'scores')
     extra = 0
 
     def scores(self, instance):
@@ -112,7 +112,7 @@ class ReviewScoreInline(admin.TabularInline):
 
 
 class ReviewAdmin(CompareVersionAdmin):
-    list_display = ('talk', 'reviewer', 'total_score', 'is_current')
+    list_display = ('talk', 'reviewer', 'avg_score', 'is_current')
     inlines = (ReviewScoreInline,)
 
 

--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -156,7 +156,9 @@ class ReviewForm(forms.Form):
                 except Score.DoesNotExist:
                     initial = None
             self.fields['aspect_{}'.format(aspect.pk)] = forms.IntegerField(
-                initial=initial, label=aspect.name, min_value=0, max_value=10)
+                initial=initial, label=aspect.name,
+                min_value=settings.WAFER_TALK_REVIEW_SCORES[0],
+                max_value=settings.WAFER_TALK_REVIEW_SCORES[1])
 
         self.helper = FormHelper(self)
         self.helper.form_action = reverse('wafer_talk_review',

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -235,7 +235,7 @@ class Talk(models.Model):
     @property
     def review_score(self):
         # Overridden in admin, to allow sorting
-        reviews = [review.total_score for review in self.reviews.all()]
+        reviews = [review.avg_score for review in self.reviews.all()]
         if not reviews:
             return None
         return sum(reviews) / len(reviews)
@@ -314,11 +314,11 @@ class Review(models.Model):
 
     def __str__(self):
         return u'Review of %s by %s (%s)' % (
-            self.reviewer, self.talk.title, self.total_score)
+            self.reviewer, self.talk.title, self.avg_score)
 
     @property
-    def total_score(self):
-        return self.scores.aggregate(total=models.Sum('value'))['total']
+    def avg_score(self):
+        return self.scores.aggregate(total=models.Avg('value'))['total']
 
     def is_current(self):
         def last_updated(obj):
@@ -347,9 +347,9 @@ class Score(models.Model):
                                related_name='scores')
     aspect = models.ForeignKey(ReviewAspect, on_delete=models.CASCADE)
 
-    value = models.IntegerField(default=1, validators=[
-        validators.MinValueValidator(0),
-        validators.MaxValueValidator(10)
+    value = models.IntegerField(default=0, validators=[
+        validators.MinValueValidator(settings.WAFER_TALK_REVIEW_SCORES[0]),
+        validators.MaxValueValidator(settings.WAFER_TALK_REVIEW_SCORES[1])
     ])
 
     def __str__(self):


### PR DESCRIPTION
This makes them a little easier to deal with.

This had been something I was considering, and I think @gwolf would prefer it.

Additionally, I think using averages everywhere will make adding generic filters for score ranges easier.