### PR TITLE
Bug/fix withdrawn talk display

### DIFF
--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -20,7 +20,11 @@
           <span class="badge badge-success" title="{% trans 'Provisionally Accepted' %}">{{ talk.status }}</span>
         {% endif %}
         {% reviewed_badge user talk %}
+        {% if talk.withdrawn %}
+        <del><a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a></del>
+        {% else %}
         <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
+        {% endif %}
         by
         <span class="author">{{ talk.get_authors_display_name }}</span>
       </div>

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -154,18 +154,15 @@ class TalkWithdraw(EditOwnTalksMixin, DeleteView):
     template_name = 'wafer.talks/talk_withdraw.html'
     success_url = reverse_lazy('wafer_page')
 
+    @revisions.create_revision()
     def delete(self, request, *args, **kwargs):
         """Override delete to only withdraw"""
         talk = self.get_object()
         talk.status = WITHDRAWN
         talk.save()
-        return HttpResponseRedirect(self.success_url)
-
-    @revisions.create_revision()
-    def form_valid(self, form):
         revisions.set_user(self.request.user)
         revisions.set_comment("Talk Withdrawn")
-        return super(TalkWithdraw, self).form_valid(form)
+        return HttpResponseRedirect(self.success_url)
 
 
 class TalkReview(PermissionRequiredMixin, CreateView):


### PR DESCRIPTION
We don't mark withdrawn talks clearly in the full talks list, which is not a great idea.

Withdrawing a talk was also not properly recorded as a revision, so this fixes that as well.