### PR TITLE
Use timezone-aware timestamps to generate the Pentabarf XML schedule …

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -26,9 +26,8 @@
                 {% if row_venue == venue and items.item %}
                   {# The event id is the ScheduleItem pk, which should be unique enough #}
                   <event id="{{ items.item.pk }}">
-                    {# Not sure what to do about timezones here #}
-                    <date>{{ schedule_day.day.date|date:"Y-m-d" }}T{{ row.slot.get_start_time|time:"H:i:s" }}+00:00</date>
-                    <start>{{ row.slot.get_start_time|time:"H:i" }}</start>
+                    <date>{{ row.start_time.isoformat }}</date>
+                    <start>{{ row.start_time|time:"H:i" }}</start>
                     {% with dur=items.item.get_duration %}
                       <duration>{{ dur.hours|stringformat:"02d" }}:{{ dur.minutes|stringformat:"02d" }}</duration>
                     {% endwith %}

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.views.generic import DetailView, TemplateView, View
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponse
+from django.utils import timezone
 
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser
@@ -21,8 +22,10 @@ from wafer.talks.models import Talk
 class ScheduleRow(object):
     """This is a helpful containter for the schedule view to keep sanity"""
     def __init__(self, schedule_day, slot):
+        tz = timezone.get_default_timezone()
         self.schedule_day = schedule_day
         self.slot = slot
+        self.start_time = timezone.make_aware(slot.get_start_datetime(), tz)
         self.items = {}
 
     def get_sorted_items(self):


### PR DESCRIPTION
…export

This assumes that the database is set to the local conference timezone, which
seems to be reasonable.

Closes: #437