### PR TITLE
Fix inconsitent author formatting

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/schedule_item.html
+++ b/wafer/schedule/templates/wafer.schedule/schedule_item.html
@@ -11,6 +11,7 @@
 {% elif item.get_url %}
   <a href="{{ item.get_url }}">{{ item.get_details|escape }}</a>
   {% if item.page and item.page.people.exists %}
+    <br>
     by {{ item.page.get_people_display_names }}
   {% endif %}
 {% else %}


### PR DESCRIPTION
The talk items force a break between the title and the author list,
while pages don't. This inconsistent formatting looks rather
odd and shouldn't be part of the default template.