### PR TITLE
Group talk by talk type in the talks list

### DIFF
--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -4,34 +4,41 @@
 {% block title %}{% trans "Talks" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <section class="wafer wafer-talks">
+  {% regroup talk_list by talk_type.name as grouped_talks %}
+  {% for type, talks in grouped_talks %}
+  {% if type %}
+  <h1>{{ type }}</h1>
+  {% else %}
   <h1>{% trans 'Talks' %}</h1>
-  <div class="wafer list">
-    {% for talk in talk_list %}
-      <div>
-        {% if talk.submitted %}
-          <span class="badge badge-info" title="{% trans 'Submitted' %}">{{ talk.status }}</span>
-        {% elif talk.under_consideration %}
-          <span class="badge badge-info" title="{% trans 'Under consideration' %}">{{ talk.status }}</span>
-        {% elif talk.reject %}
-          <span class="badge badge-danger" title="{% trans 'Not accepted' %}">{{ talk.status }}</span>
-        {% elif talk.cancelled %}
-          <span class="badge badge-warning" title="{% trans 'Talk Cancelled' %}">{{ talk.status }}</span>
-        {% elif talk.provisional %}
-          <span class="badge badge-success" title="{% trans 'Provisionally Accepted' %}">{{ talk.status }}</span>
-        {% endif %}
-        {% reviewed_badge user talk %}
-        {% if talk.withdrawn %}
-        <del><a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a></del>
-        {% else %}
-        <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
-        {% endif %}
-        by
-        <span class="author">{{ talk.get_authors_display_name }}</span>
-      </div>
-    {% empty %}
-      <p>No talks accepted yet.</p>
-    {% endfor %}
-  </div>
+  {% endif %}
+     <div class="wafer list">
+       {% for talk in talks %}
+         <div>
+           {% if talk.submitted %}
+             <span class="badge badge-info" title="{% trans 'Submitted' %}">{{ talk.status }}</span>
+           {% elif talk.under_consideration %}
+             <span class="badge badge-info" title="{% trans 'Under consideration' %}">{{ talk.status }}</span>
+           {% elif talk.reject %}
+             <span class="badge badge-danger" title="{% trans 'Not accepted' %}">{{ talk.status }}</span>
+           {% elif talk.cancelled %}
+             <span class="badge badge-warning" title="{% trans 'Talk Cancelled' %}">{{ talk.status }}</span>
+           {% elif talk.provisional %}
+             <span class="badge badge-success" title="{% trans 'Provisionally Accepted' %}">{{ talk.status }}</span>
+           {% endif %}
+           {% reviewed_badge user talk %}
+           {% if talk.withdrawn %}
+           <del><a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a></del>
+           {% else %}
+           <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
+           {% endif %}
+           by
+           <span class="author">{{ talk.get_authors_display_name }}</span>
+         </div>
+       {% empty %}
+         <p>No talks accepted yet.</p>
+       {% endfor %}
+     </div>
+   {% endfor %}
 </section>
 {% if is_paginated %}
   <section class="wafer wafer-pagination">

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -42,7 +42,7 @@ class UsersTalks(ListView):
     template_name = 'wafer.talks/talks.html'
     paginate_by = 25
 
-    @order_results_by('talk_id')
+    @order_results_by('talk_type', 'talk_id')
     def get_queryset(self):
         # self.request will be None when we come here via the static site
         # renderer
@@ -246,7 +246,7 @@ class TalksViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
     # XXX: Do we want to allow authors to edit talks via the API?
     permission_classes = (DjangoModelPermissionsOrAnonReadOnly, )
 
-    @order_results_by('talk_id')
+    @order_results_by('talk_type', 'talk_id')
     def get_queryset(self):
         # We override the default implementation to only show accepted talks
         # to people who aren't part of the management group


### PR DESCRIPTION
The current talk list doesn't display the talk type, and just sorts the talks by submission order, which can be confusing when several different types are involved.

This groups the list into the different types.

We arguably want to add some sort of "list_title" field to talk types, since it looks a bit odd to use the singular form in the list, and equally odd to use the plural for submissions, and trying to do something automatic will be hard for translation.