### PR TITLE
Correctly mark withdrawn talks on the individual talk page

### DIFF
--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -87,6 +87,8 @@
           <span class="badge badge-success">{% trans 'Accepted' %}</span>
         {% elif object.cancelled %}
           <span class="badge badge-warning">{% trans 'Cancelled' %}</span>
+        {% elif object.withdrawn %}
+          <span class="badge badge-warning ">{% trans 'Withdrawn' %}</span>
         {% else %}
           <span class="badge badge-danger">{% trans 'Not accepted' %}</span>
         {% endif %}


### PR DESCRIPTION
Withdrawn talks are marked as "not accepted" when an admin looks at the individual talk page, which is unexpected.