### PR TITLE
Add a WAFER_VIDEO_LICENSE setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -120,6 +120,10 @@ Wafer's settings
     email address of someone who will review the talk's video, once it
     is ready to publish.
 
+``WAFER_VIDEO_LICENSE``
+    The name of the license that the conference's videos will be
+    released under. Talk submitters will be asked to release their video
+    under this license.
 
 Third party settings
 ====================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -125,6 +125,9 @@ Wafer's settings
     released under. Talk submitters will be asked to release their video
     under this license.
 
+``WAFER_VIDEO_LICENSE_URL``
+    Link to the full text of ``WAFER_VIDEO_LICENSE``.
+
 Third party settings
 ====================
 

--- a/wafer/context_processors.py
+++ b/wafer/context_processors.py
@@ -42,6 +42,7 @@ def registration_settings(request):
             'WAFER_HIDE_LOGIN',
             'WAFER_REGISTRATION_OPEN',
             'WAFER_REGISTRATION_MODE',
+            'WAFER_VIDEO_LICENSE',
     ):
         context[setting] = getattr(settings, setting, None)
     return context

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -71,6 +71,9 @@
                         </persons>
                         <abstract/>
                         <released>{{ talk.video }}</released>
+                        {% if talk.video %}
+                          <license>{{ WAFER_VIDEO_LICENSE }}</license>
+                        {% endif %}
                       {% endwith %}
                     {% else %}
                       <title>{{ items.item.get_details|escape }}</title>
@@ -103,6 +106,7 @@
                         <description/>
                       {% endif %}
                       <released>True</released>
+                      <license>{{ WAFER_VIDEO_LICENSE }}</license>
                     {% endif %}
                     <conf_url>{{ items.item.get_url }}</conf_url>
                     {# It's useful to have the full url available in the xml file. The pentabarf.xml format isn't that well #}

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -278,7 +278,8 @@ WAFER_TALK_FORM = 'wafer.talks.forms.TalkForm'
 # Ask speakers for video release, and an email address of a reviewer
 WAFER_VIDEO = True
 WAFER_VIDEO_REVIEWER = True
-WAFER_VIDEO_LICENSE = 'CC-BY-SA'
+WAFER_VIDEO_LICENSE = 'CC BY-SA 4.0'
+WAFER_VIDEO_LICENSE_URL = 'https://creativecommons.org/licenses/by-sa/4.0/'
 
 # Range of scores for talk reviews (inclusive)
 WAFER_TALK_REVIEW_SCORES = (-2, 2)

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -278,6 +278,7 @@ WAFER_TALK_FORM = 'wafer.talks.forms.TalkForm'
 # Ask speakers for video release, and an email address of a reviewer
 WAFER_VIDEO = True
 WAFER_VIDEO_REVIEWER = True
+WAFER_VIDEO_LICENSE = 'CC-BY-SA'
 
 # Range of scores for talk reviews (inclusive)
 WAFER_TALK_REVIEW_SCORES = (-2, 2)

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -159,8 +159,9 @@ class Talk(models.Model):
         default=True,
         help_text=_(
             "By checking this, you are giving permission for the talk to be "
-            "videoed, and distributed by the conference, under the %s license."
-        ) % settings.WAFER_VIDEO_LICENSE)
+            "videoed, and distributed by the conference, under the "
+            '<a href="%s">%s license</a>.'
+        ) % (settings.WAFER_VIDEO_LICENSE_URL, settings.WAFER_VIDEO_LICENSE))
     video_reviewer = models.EmailField(
         null=True, blank=True,
         help_text=_(

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -159,9 +159,8 @@ class Talk(models.Model):
         default=True,
         help_text=_(
             "By checking this, you are giving permission for the talk to be "
-            "videoed, and distributed by the conference, under a license of "
-            "their choice."
-        ))
+            "videoed, and distributed by the conference, under the %s license."
+        ) % settings.WAFER_VIDEO_LICENSE)
     video_reviewer = models.EmailField(
         null=True, blank=True,
         help_text=_(


### PR DESCRIPTION
Show the license on the talk submission form, and include the license in the pentabarf XML export.

Fixes: #449

This ignores #450, where we may want to remove the pentabarf bit.