### PR TITLE
Bugs/issue 436 return 403 for all profiles

### DIFF
--- a/wafer/users/tests/test_views.py
+++ b/wafer/users/tests/test_views.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# vim:fileencoding=utf-8 ai ts=4 sts=4 et sw=4
+"""Tests for wafer.user.views"""
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from wafer.talks.models import Talk, ACCEPTED
+
+
+class UserProfileTests(TestCase):
+
+    def setUp(self):
+        create = get_user_model().objects.create_user
+        # Create 2 users
+        create("test1", "test@example.com", "test_password")
+        create("test2", "test@example.com", "test_password")
+        user3 = create("test3", "test@example.com", "test_password")
+        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
+                                   corresponding_author_id=user3.id)
+        talk.authors.add(user3)
+        self.client = Client()
+
+    def test_not_logged_in_private_userlist(self):
+        """We should get 403 for both existing and non-existant users.
+        
+           We can see the user with the accepted talk."""
+        with self.settings(WAFER_PUBLIC_ATTENDEE_LIST=False):
+            response = self.client.get('/users/test1/')
+            self.assertEqual(response.status_code, 403)
+            response = self.client.get('/users/test1/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+            response = self.client.get('/users/test2/')
+            self.assertEqual(response.status_code, 403)
+            response = self.client.get('/users/test2/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+            response = self.client.get('/users/test3/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test3/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+            response = self.client.get('/users/does_not_exist/')
+            self.assertEqual(response.status_code, 403)
+            response = self.client.get('/users/does_not_exist/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+    def test_logged_in_private_userlist(self):
+        """We can see and edit our own profile, but get 403's for existing and
+           non-existing users.
+           
+           We can see the user with an accepted talk, but not edit."""
+        self.client.login(username='test1', password="test_password")
+        with self.settings(WAFER_PUBLIC_ATTENDEE_LIST=False):
+            response = self.client.get('/users/test1/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test1/edit_profile/')
+            self.assertEqual(response.status_code, 200)
+
+            response = self.client.get('/users/test2/')
+            self.assertEqual(response.status_code, 403)
+            response = self.client.get('/users/test2/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+            response = self.client.get('/users/test3/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test3/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+            response = self.client.get('/users/does_not_exist/')
+            self.assertEqual(response.status_code, 403)
+            response = self.client.get('/users/does_not_exist/edit_profile/')
+            self.assertEqual(response.status_code, 403)
+
+    def test_not_logged_in_public_userlist(self):
+        """We should be able to access profiles, but not edit them.
+
+           we should get 404's for non-existing users and other bits
+           we can't access."""
+        with self.settings(WAFER_PUBLIC_ATTENDEE_LIST=True):
+            response = self.client.get('/users/test1/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test1/edit_profile/')
+            self.assertEqual(response.status_code, 404)
+
+            response = self.client.get('/users/test2/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test2/edit_profile/')
+            self.assertEqual(response.status_code, 404)
+
+            response = self.client.get('/users/test3/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test3/edit_profile/')
+            self.assertEqual(response.status_code, 404)
+
+            response = self.client.get('/users/does_not_exist/')
+            self.assertEqual(response.status_code, 404)
+            response = self.client.get('/users/does_not_exist/edit_profile/')
+            self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_pulic_userlist(self):
+        """We should be able to edit our profile.
+           We should be able to access other profiles, but not edit them.
+
+           we should get 404's for non-existing users."""
+        self.client.login(username='test1', password="test_password")
+        with self.settings(WAFER_PUBLIC_ATTENDEE_LIST=True):
+            response = self.client.get('/users/test1/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test1/edit_profile/')
+            self.assertEqual(response.status_code, 200)
+
+            response = self.client.get('/users/test2/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test2/edit_profile/')
+            self.assertEqual(response.status_code, 404)
+
+            response = self.client.get('/users/test3/')
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get('/users/test3/edit_profile/')
+            self.assertEqual(response.status_code, 404)
+
+            response = self.client.get('/users/does_not_exist/')
+            self.assertEqual(response.status_code, 404)
+            response = self.client.get('/users/does_not_exist/edit_profile/')
+            self.assertEqual(response.status_code, 404)

--- a/wafer/users/views.py
+++ b/wafer/users/views.py
@@ -35,7 +35,25 @@ class UsersView(PaginatedBuildableListView):
         return qs
 
 
-class ProfileView(BuildableDetailView):
+class Hide404Mixin(object):
+    """Generic handling for user objects.
+
+       To prevent information leakage, we turn all 404's into
+       403's when the attendee list isn't public."""
+    def get(self, *args, **kwargs):
+        try:
+            result = super(Hide404Mixin, self).get(*args, **kwargs)
+        except Http404:
+            if not settings.WAFER_PUBLIC_ATTENDEE_LIST:
+                # We convert all 404's to 403's to prevent info leakage
+                # about which users actually exist and which are
+                # just private.
+                raise PermissionDenied()
+            # For public attendee lists, 404 is the right thing
+            raise
+        return result
+
+class ProfileView(Hide404Mixin, BuildableDetailView):
     template_name = 'wafer.users/profile.html'
     model = get_user_model()
     slug_field = 'username'
@@ -58,19 +76,6 @@ class ProfileView(BuildableDetailView):
             # cleanup directory
             self.unbuild_object(obj)
 
-    def get(self, *args, **kwargs):
-        try:
-            result = super(ProfileView, self).get(*args, **kwargs)
-        except Http404:
-            if not settings.WAFER_PUBLIC_ATTENDEE_LIST:
-                # We convert all 404's to 403's to prevent info leakage
-                # about which users actually exist and which are
-                # just private.
-                raise PermissionDenied()
-            # For public attendee lists, 404 is the right thing
-            raise
-        return result
-
     def get_object(self, *args, **kwargs):
         object_ = super(ProfileView, self).get_object(*args, **kwargs)
         if not settings.WAFER_PUBLIC_ATTENDEE_LIST:
@@ -91,7 +96,8 @@ class ProfileView(BuildableDetailView):
 
 
 # TODO: Combine these
-class EditOneselfMixin(object):
+class EditOneselfMixin(Hide404Mixin):
+    """Extend the behaviour with edit permission checks."""
     def get_object(self, *args, **kwargs):
         object_ = super(EditOneselfMixin, self).get_object(*args, **kwargs)
         self.verify_edit_permission(object_)


### PR DESCRIPTION
Hopefully addresses #436 

This should return 403 for all user related urls when WAFER_PUBLIC_ATTENDEE_LIST is False and the user isn't logged in.

We are probably too aggressive about returning 404's when WAFER_PUBLIC_ATTENDEE_LIST is True, (see the tests) but I haven't thought through all the implications of changing the behaviour.