### PR TITLE
profile page improvements

### DIFF
--- a/wafer/context_processors.py
+++ b/wafer/context_processors.py
@@ -42,6 +42,7 @@ def registration_settings(request):
             'WAFER_HIDE_LOGIN',
             'WAFER_REGISTRATION_OPEN',
             'WAFER_REGISTRATION_MODE',
+            'WAFER_TALKS_OPEN',
             'WAFER_VIDEO_LICENSE',
     ):
         context[setting] = getattr(settings, setting, None)

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -288,7 +288,8 @@ WAFER_TALK_REVIEW_SCORES = (-2, 2)
 WAFER_REGISTRATION_OPEN = True
 
 # WAFER_REGISTRATION_MODE can be 'ticket' for Quicket tickets, or 'custom' if
-# you implement your own registration system.
+# you implement your own registration system. If 'custom', then you *must*
+# define a URL named 'register' in your application so we can link to it.
 WAFER_REGISTRATION_MODE = 'ticket'
 # WAFER_USER_IS_REGISTERED should return a boolean, when passed a Django user.
 WAFER_USER_IS_REGISTERED = 'wafer.tickets.models.user_is_registered'

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -30,12 +30,15 @@
           <ul class="float-right btn-group btn-group-vertical profile-links">
             <li><a href="{% url 'wafer_user_edit' object.username %}" class="btn btn-secondary">{% trans 'Edit User' %}</a></li>
             <li><a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn btn-secondary">{% trans 'Edit Profile' %}</a></li>
-            {% if WAFER_REGISTRATION_OPEN and not profile.is_registered %}
-              {% if WAFER_REGISTRATION_MODE == 'ticket' %}
+            {% if WAFER_REGISTRATION_OPEN %}
+              {% if WAFER_REGISTRATION_MODE == 'ticket' and not profile.is_registered  %}
                 {% url 'wafer_ticket_claim' as register_url %}
               {% endif %}
+              {% if WAFER_REGISTRATION_MODE == 'custom' %}
+                {% url 'register' as register_url %}
+              {% endif %}
               {% if register_url %}
-                <li><a href="{{ register_url }}" class="btn btn-secondary">{% trans 'Register' %}</a></li>
+                <li><a href="{{ register_url }}" class="btn btn-secondary">{% if profile.is_registered %}{% trans 'Update registration' %}{% else %}{% trans 'Register' %}{% endif %}</a></li>
               {% endif %}
             {% endif %}
             {% if WAFER_TALKS_OPEN %}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -38,7 +38,9 @@
                 <li><a href="{{ register_url }}" class="btn btn-secondary">{% trans 'Register' %}</a></li>
               {% endif %}
             {% endif %}
-            <li><a href="{% url 'wafer_talk_submit' %}" class="btn btn-secondary">{% trans 'Submit Talk Proposal' %}</a></li>
+            {% if WAFER_TALKS_OPEN %}
+              <li><a href="{% url 'wafer_talk_submit' %}" class="btn btn-secondary">{% trans 'Submit Talk Proposal' %}</a></li>
+            {% endif %}
           </ul>
         {% endif %}
         {% spaceless %}


### PR DESCRIPTION
While I was working on the DebConf19 registration, I ended up making these
changes to 1) link to registration from the profile and 2) hide the "Submit
Talk Proposal" if WAFER_TALKS_OPEN is False.

I do realize this conflicts with #440, and that we will have to override the
entire profile page for DebConf 19 anyway. But this looks like an incremental
change that could be useful enough in wafer upstream.