### PR TITLE
Feature/style markitup preview

### DIFF
--- a/wafer/pages/templates/wafer.pages/page_form.html
+++ b/wafer/pages/templates/wafer.pages/page_form.html
@@ -2,6 +2,10 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 {% load static from staticfiles %}
+{% block extra_head %}
+{{ block.super }}
+<link href="{% static 'css/markitup_styling.css' %}" type="text/css" media="screen" rel="stylesheet" />
+{% endblock %}
 {% block content %}
 <section class="wafer wafer-page-edit">
 <h1>{% trans "Edit Page" %}</h1>

--- a/wafer/static/css/markitup_styling.css
+++ b/wafer/static/css/markitup_styling.css
@@ -1,0 +1,12 @@
+/* -------------------------------------------------------------------
+ * Local additional styling for markitup widgets
+// ------------------------------------------------------------------*/
+.markItUp  {
+	width:99%;
+}
+.markItUpEditor {
+	width:85%;
+}
+.markItUpPreviewFrame	{
+	width:99.9%;
+}

--- a/wafer/templates/markitup/preview.html
+++ b/wafer/templates/markitup/preview.html
@@ -1,0 +1,12 @@
+{% extends "wafer/base.html" %}
+{% load i18n %}
+{% block content %}
+<div class="alert alert-warning" role="alert">
+   {% blocktrans %}
+   This is only a preview of the page. It has not yet been updated.
+   {% endblocktrans %}
+</div>
+<div>
+  {{ preview|safe }}
+</div>
+{% endblock %}


### PR DESCRIPTION
To make the markitup preview widget more useful, this adds a template so the preview view is correctly styled.

It also adds a small bit of css to tweak the widget layout (needed since the default for the preview is very narrow), since markitup's widgets load their custom styling after wafer.css is loaded and we don't want to pull in all the markitup styling into wafer.