### PR TITLE
Talk: exclude reviews with no score when calculating average

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -235,7 +235,7 @@ class Talk(models.Model):
     @property
     def review_score(self):
         # Overridden in admin, to allow sorting
-        reviews = [review.avg_score for review in self.reviews.all()]
+        reviews = [review.avg_score for review in self.reviews.all() if review.avg_score]
         if not reviews:
             return None
         return sum(reviews) / len(reviews)


### PR DESCRIPTION
This can happen when a reviewer goes over the talks before review aspects
are defined, and leaves a comment in the notes field; the reviewer will
be able to save a Review that has no avg_score.

Filtering such reviews out stops Talk.review_score from crashing.