### PR TITLE
Bugs/pin drf extensions to py2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     'django-nose',
     'django-registration-redux',
     'djangorestframework',
-    'drf-extensions',
+    'drf-extensions<0.5',
     'jsonfield',
     'pillow',
     'diff-match-patch',

--- a/wafer/talks/urls.py
+++ b/wafer/talks/urls.py
@@ -8,6 +8,7 @@ from wafer.talks.views import (
 
 router = routers.ExtendedSimpleRouter()
 
+# FIXME: Change base_name when we drop python 2 and move to drf-extensions 0.5
 talks_router = router.register(r'talks', TalksViewSet)
 talks_router.register(
     r'urls', TalkUrlsViewSet, base_name='talks-urls',


### PR DESCRIPTION
Fixes the currently failing set of builds

We should plan to drop python 2 support ourselves at some point, as that's going to get increasingly painful