### PR TITLE
wafer_speaker_contact_details: fix output

### DIFF
--- a/wafer/management/commands/wafer_speaker_contact_details.py
+++ b/wafer/management/commands/wafer_speaker_contact_details.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
                           person.talks.filter(status=ACCEPTED)]
                 if not titles:
                     continue
-            row = [x.encode("utf-8")
+            row = [x
                    for x in (person.userprofile.display_name(), person.email,
                    person.userprofile.contact_number or 'NO CONTACT INFO',
                    ';'.join(titles))]


### PR DESCRIPTION
This fixes the CSV output for wafer_speaker_contact_details on python3.
I'm not sure sure it this would still be needed under python 2, but I
would assume that a recent enough Django will do the right thing either
way.