### PR TITLE
Separate speaker names on the individual talks page

### DIFF
--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -34,6 +34,9 @@
       {% endblocktrans %}
       {% for author in object.authors.all %}
         <a href="{% url 'wafer_user_profile' username=author.username %}">{{ author.userprofile.display_name }}</a>
+          {% if not forloop.last %}
+            &amp;
+          {% endif %}
       {% endfor %}
     </p>
     {% if user.is_staff or perms.talks.view_all_talks %}


### PR DESCRIPTION
The current page of individual talks doesn't clearly separate multiple speakers.

This adds a '&' between each speaker - I've opted not to make the logic more complicated as I think the clear visual separation is useful even for talks with more than 2 speakers.