### PR TITLE
Bug/fix css display

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -372,7 +372,7 @@ class ScheduleItemAdmin(CompareVersionAdmin):
     form = ScheduleItemAdminForm
 
     change_list_template = 'admin/scheduleitem_list.html'
-    readonly_fields = ('get_css_classes',)
+    readonly_fields = ('list_css_classes',)
     list_display = ('get_start_time', 'venue', 'get_title', 'expand')
     list_editable = ('expand',)
 

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -203,7 +203,11 @@ class ScheduleItem(models.Model):
             if self.talk.track:
                 yield self.talk.track.css_class()
 
-    get_css_classes.short_description = 'Talk Type & Track CSS classes'
+    def list_css_classes(self):
+        """Convert get_css_classes into a nice string for the admin interface"""
+        return ',  '.join(list(self.get_css_classes()))
+
+    list_css_classes.short_description = _('Talk Type & Track CSS classes')
 
     def get_desc(self):
         if self.details:

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -101,7 +101,7 @@ class Slot(models.Model):
 
     def get_formatted_start_time(self):
         return self.get_start_time().strftime('%H:%M')
-    get_formatted_start_time.short_description = 'Start Time'
+    get_formatted_start_time.short_description = _('Start Time')
 
     def get_formatted_end_time(self):
         return self.end_time.strftime('%H:%M')
@@ -131,7 +131,7 @@ class Slot(models.Model):
         if self.previous_slot:
             return self.previous_slot.get_day()
         return self.day
-    get_day.short_description = 'Day'
+    get_day.short_description = _('Day')
 
     def clean(self):
         """Ensure we have start_time < end_time"""
@@ -245,7 +245,7 @@ class ScheduleItem(models.Model):
             return u'%s, %s' % (day, start)
         else:
             return 'WARNING: No Time and Day Specified'
-    get_start_time.short_description = 'Start Time'
+    get_start_time.short_description = _('Start Time')
 
     def __str__(self):
         return u'%s in %s at %s' % (self.get_desc(), self.venue,


### PR DESCRIPTION
Django currently displays the repr of the get_css_classes generator, which is not particularly useful, so we wrap the generator to get a nice string for the admin interface.