### PR TITLE
load_pages: drop deprecated used of yaml.load()

### DIFF
--- a/wafer/pages/management/commands/load_pages.py
+++ b/wafer/pages/management/commands/load_pages.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                 if line == '---\n':
                     break
                 front_matter.append(line)
-            meta = yaml.load(''.join(front_matter))
+            meta = yaml.safe_load(''.join(front_matter))
             contents = ''.join(f)
         return meta, contents
 


### PR DESCRIPTION
Since yaml.safe_load is just fine in that context.