### PR TITLE
templates: trim blocktrans strings

### DIFF
--- a/wafer/registration/templates/registration/activate.html
+++ b/wafer/registration/templates/registration/activate.html
@@ -5,7 +5,7 @@
 <p>
 {% url 'registration_register' as register_url %}
 {% url 'wafer_page' 'contact' as contact_url %}
-{% blocktrans %}
+{% blocktrans trimmed %}
     We seem to have had some difficulty with our registration.
     Please <a href="{{ register_url }}">try again</a>
     or <a href="{{ contact_url }}">contact our admins</a>.

--- a/wafer/registration/templates/registration/activation_complete.html
+++ b/wafer/registration/templates/registration/activation_complete.html
@@ -4,7 +4,7 @@
 <h1>{% trans 'Activation complete' %}</h1>
 <p>
 {% url 'auth_login' as login_url %}
-{% blocktrans %}
+{% blocktrans trimmed %}
     You are registered!
     Please <a href="{{ login_url }}">log in</a>.
 {% endblocktrans %}

--- a/wafer/registration/templates/registration/login.html
+++ b/wafer/registration/templates/registration/login.html
@@ -15,7 +15,7 @@
         <div class="col-md-6">
             <h2>{% trans 'Sign up' %}</h2>
             {% url 'registration_register' as signup_url %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
             Not registered? Please <a href="{{signup_url}}">sign up</a>.
             {% endblocktrans %}
             {% if WAFER_SSO %}

--- a/wafer/registration/templates/registration/logout.html
+++ b/wafer/registration/templates/registration/logout.html
@@ -6,7 +6,7 @@
       <div class="col-md-6">
          <h2>{% trans 'Logged out' %}</h2>
          <p>
-         {% blocktrans %}
+         {% blocktrans trimmed %}
              You've been logged out.
          {% endblocktrans %}
          </p>

--- a/wafer/registration/templates/registration/registration_complete.html
+++ b/wafer/registration/templates/registration/registration_complete.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>{% trans 'Registration almost complete' %}</h1>
 <p>
-{% blocktrans %}
+{% blocktrans trimmed %}
     Thank you for registering for {{ WAFER_CONFERENCE_NAME }}.
     We have sent you an e-mail.
     Please follow the instructions in it to complete your registration.

--- a/wafer/schedule/templates/wafer.schedule/current.html
+++ b/wafer/schedule/templates/wafer.schedule/current.html
@@ -7,11 +7,11 @@
   <div class="wafer_schedule">
     {% if not active %}
       {# Schedule is incomplete / invalid, so show nothing #}
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         <p>The final schedule has not been published yet.</p>
       {% endblocktrans %}
     {% elif not slots %}
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         <p>Nothing happening right now.</p>
       {% endblocktrans %}
     {% else %}

--- a/wafer/schedule/templates/wafer.schedule/full_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/full_schedule.html
@@ -17,7 +17,7 @@
   <div class="wafer_schedule">
     {% if not schedule_pages %}
       {# Schedule is incomplete / invalid, so show nothing #}
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         <p>The final schedule has not been published yet.</p>
       {% endblocktrans %}
     {% else %}

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -27,7 +27,7 @@
   </h1>
   <div>
     <p>
-      {% blocktrans count counter=object.authors.count %}
+      {% blocktrans trimmed count counter=object.authors.count %}
         Speaker:
       {% plural %}
         Speakers:
@@ -42,11 +42,11 @@
     {% if user.is_staff or perms.talks.view_all_talks %}
       {% for author in object.authors.all %}
         <p class="bio">
-          {% blocktrans %}Bio{% endblocktrans %}{% if object.authors.count > 1 %} - {{ author.userprofile.display_name }}{% endif %}:
+          {% blocktrans trimmed %}Bio{% endblocktrans %}{% if object.authors.count > 1 %} - {{ author.userprofile.display_name }}{% endif %}:
           {% if author.userprofile.bio %}
             {{ author.userprofile.bio }}
           {% else %}
-            <em>{% blocktrans %}Not provided{% endblocktrans %}</em>
+            <em>{% blocktrans trimmed %}Not provided{% endblocktrans %}</em>
           {% endif %}
         </p>
       {% endfor %}
@@ -54,14 +54,14 @@
 
     {% if object.track %}
       <p>
-        {% blocktrans with track=object.track.name %}
+        {% blocktrans trimmed with track=object.track.name %}
           Track:
           {{ track }}
         {% endblocktrans %}
       </p>
     {% endif %}
     <p>
-      {% blocktrans with talk_type=object.talk_type.name|default:_('Talk') %}
+      {% blocktrans trimmed with talk_type=object.talk_type.name|default:_('Talk') %}
         Type:
         {{ talk_type }}
       {% endblocktrans %}
@@ -69,19 +69,19 @@
     {% if object.get_in_schedule %}
       {% for schedule in object.scheduleitem_set.all %}
         <p>
-          {% blocktrans with venue=schedule.venue %}
+          {% blocktrans trimmed with venue=schedule.venue %}
             Room:
             {{ venue }}
           {% endblocktrans %}
         </p>
         <p>
-          {% blocktrans with start_time=schedule.get_start_time %}
+          {% blocktrans trimmed with start_time=schedule.get_start_time %}
             Time:
             {{ start_time }}
           {% endblocktrans %}
         </p>
         <p>
-          {% blocktrans with hours=schedule.get_duration.hours|stringformat:"d" minutes=schedule.get_duration.minutes|stringformat:"02d" %}
+          {% blocktrans trimmed with hours=schedule.get_duration.hours|stringformat:"d" minutes=schedule.get_duration.minutes|stringformat:"02d" %}
             Duration:
             {{ hours }}:{{ minutes }}
           {% endblocktrans %}
@@ -95,7 +95,7 @@
         {% trans 'Submission:' %}
         {{ object.submission_time }}
         {% if object.is_late_submission %}
-        <span class="badge badge-warning ">{% blocktrans %}Late submission{% endblocktrans %}</span>
+        <span class="badge badge-warning ">{% blocktrans trimmed %}Late submission{% endblocktrans %}</span>
         {% endif %}
       </p>
     </div>
@@ -127,7 +127,7 @@
     {% if talk.notes %}
       <div id="notes" class="card mb-3">
         <div class="card-header">
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             <h2>Talk Notes</h2>
             <p>(The following is not visible to attendees.)</p>
           {% endblocktrans %}
@@ -143,7 +143,7 @@
   {% if perms.talks.edit_private_notes and object.private_notes %}
     <div id="private_notes" class="card mb-3">
       <div class="card-header">
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           <h2>Private notes</h2>
           <p>(The following is not visible to submitters or attendees.)</p>
         {% endblocktrans %}

--- a/wafer/talks/templates/wafer.talks/talk_form.html
+++ b/wafer/talks/templates/wafer.talks/talk_form.html
@@ -8,7 +8,7 @@
     <h1>{% trans "Edit Talk" %}</h1>
     {% with corresponding_author_name=object.corresponding_author.userprofile.display_name %}
       {% url 'wafer_user_profile' username=object.corresponding_author.username as corresponding_author_url %}
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         <p>Submitted by <a href="{{ corresponding_author_url }}">{{ corresponding_author_name }}</a>.</p>
       {% endblocktrans %}
     {% endwith %}
@@ -16,7 +16,7 @@
     <h1>{% trans "Talk Submission" %}</h1>
   {% endif %}
   {% if not can_edit and not can_submit %}
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       <em>Talk submission is closed</em>
     {% endblocktrans %}
   {% else %}

--- a/wafer/talks/templates/wafer.talks/talk_withdraw.html
+++ b/wafer/talks/templates/wafer.talks/talk_withdraw.html
@@ -4,7 +4,7 @@
 <section class="wafer wafer-talk-withdrawal">
   <h1>{% trans "Confirm Talk Withdrawal" %}</h1>
   <div class="alert alert-danger">
-   {% blocktrans with talk_title=object.title talk_url=object.get_absolute_url %}
+   {% blocktrans trimmed with talk_title=object.title talk_url=object.get_absolute_url %}
     You are about to withdraw the talk <a href="{{ talk_url }}">"{{ talk_title }}"</a>.<br>
     This cannot be undone without help from the site administrators.
     {% endblocktrans %}

--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -34,7 +34,7 @@
           {% else %}
           <a href="{{ talk.get_absolute_url }}">{{ talk.title }}</a>
           {% endif %}
-          {% blocktrans with authors=talk.get_authors_display_name %}
+          {% blocktrans trimmed with authors=talk.get_authors_display_name %}
           by <span class="author">{{ authors }}</span>
           {% endblocktrans %}
         </div>

--- a/wafer/templates/404.html
+++ b/wafer/templates/404.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 <h1>{% trans "Page not found" %}</h1>
-{% blocktrans %}
+{% blocktrans trimmed %}
 The page you requested cannot be found.
 {% endblocktrans %}
 {% endblock %}

--- a/wafer/templates/500.html
+++ b/wafer/templates/500.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 <h1>{% trans "Internal server error" %}</h1>
-{% blocktrans %}
+{% blocktrans trimmed %}
 Something went wrong while preparing the page that was requested.
 {% endblocktrans %}
 {% endblock %}

--- a/wafer/templates/markitup/preview.html
+++ b/wafer/templates/markitup/preview.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 <div class="alert alert-warning" role="alert">
-   {% blocktrans %}
+   {% blocktrans trimmed %}
    This is only a preview of the page. It has not yet been updated.
    {% endblocktrans %}
 </div>

--- a/wafer/templates/wafer/nav.html
+++ b/wafer/templates/wafer/nav.html
@@ -55,7 +55,7 @@
                 </a>
                 <ul class="dropdown-menu dropdown-menu-right">
                   <li><a class="dropdown-item" href="{% url 'wafer_user_profile' username=user.username %}">
-                    {% blocktrans with name=user.userprofile.display_name %}
+                    {% blocktrans trimmed with name=user.userprofile.display_name %}
                     {{ name }}'s profile
                     {% endblocktrans %}
                   </a></li>

--- a/wafer/tickets/templates/wafer.tickets/claim.html
+++ b/wafer/tickets/templates/wafer.tickets/claim.html
@@ -15,7 +15,7 @@
   <section class="section1">
     <h2>{% trans "Ticket claim" %}</h2>
     <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Once you have registered, claim your ticket here, to confirm your
       registration.
     {% endblocktrans %}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -17,7 +17,7 @@
               data-title="{% trans 'Changing your mugshot' %}" data-html="true"
               data-placement="bottom">{% trans 'Edit Mugshot' %}</a>
           <div class="popover-contents">
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               Pictures provided by <a href="https://www.libravatar.org/">libravatar</a>
               (which falls back to <a href="https://secure.gravatar.com/">Gravatar</a>).<br>
               Change your picture there.
@@ -82,13 +82,13 @@
       {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
         {% if profile.is_registered %}
           <div class="alert alert-success">
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               Registered
             {% endblocktrans %}
           </div>
         {% else %}
           <div class="alert alert-danger">
-            {% blocktrans %}
+            {% blocktrans trimmed %}
               <strong>WARNING:</strong>
               Talk proposal submitted, but speaker hasn't registered to attend.
             {% endblocktrans %}


### PR DESCRIPTION
Adding `trimmed` to blocktrans compacts the strings in the PO files by
trimming whitespace at the beginning and end of the text. This way if
the blocktrans block gets e.g. its indentation changed, that will not
invalidate any translations.

This also makes the PO files a lot better to work with.