### PR TITLE
settings: drop USER from PostgreSQL settings

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -24,7 +24,6 @@ DATABASES = {
 if os.environ.get('TESTDB', None) == 'postgres':
     DATABASES['default'].update({
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'USER': 'postgres',
         'NAME': 'wafer',
         })
 


### PR DESCRIPTION
This makes it possible to run against PostgreSQL without having to have
access to the `postgres` user. When USER is omitted, it will try to use
the current username. If a different username is needed, the user can
set the PGUSER environment variable.