### PR TITLE
wafer.settings: don't load localsettings

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -2,11 +2,6 @@ import os
 
 from django.utils.translation import ugettext_lazy as _
 
-try:
-    from localsettings import *
-except ImportError:
-    pass
-
 # Django settings for wafer project.
 
 ADMINS = (


### PR DESCRIPTION
Based on the documentation (docs/install.rst), the recommended way of
using wafer is in a new Django app that includes wafer settings in its
own. In that case, it's less surprising to let that app handle any local
settings loading, if any is needed. In fact, most apps using wafer that
I came about did their own loading of a localsettings module.