### PR TITLE
Bugs/force ci to work again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ REQUIRES = [
     'django-crispy-forms',
     'django-nose',
     'django-registration-redux',
-    'djangorestframework',
+    'djangorestframework<3.11',
     'drf-extensions<0.5',
     'jsonfield',
     'pillow',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES = [
     'pytz',
     'requests',
     'django-bakery>=0.12.0',
-    'django-reversion>=2.0',
+    'django-reversion>=2.0,<3.0.5',
     'django-easy-select2',
     'django-markitup>=2.2.2',
     'markdown>=2.5',


### PR DESCRIPTION
This pins our dependencies back to versions that don't break our build, until we can plan a proper migration away from python 2 and Django 1.11 support.