### PR TITLE
Talk.video: avoid interpolating string too soon

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -5,6 +5,7 @@ from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import lazy
+from django.utils.text import format_lazy
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.utils.timezone import now
 
@@ -200,11 +201,14 @@ class Talk(models.Model):
     video = models.BooleanField(
         default=True,
         verbose_name=_("video"),
-        help_text=_(
+        help_text=format_lazy(_(
             "By checking this, you are giving permission for the talk to be "
             "videoed, and distributed by the conference, under the "
-            '<a href="%s">%s license</a>.'
-        ) % (settings.WAFER_VIDEO_LICENSE_URL, settings.WAFER_VIDEO_LICENSE))
+            '<a href="{license_url}">{license_name} license</a>.'),
+            license_url=settings.WAFER_VIDEO_LICENSE_URL,
+            license_name=settings.WAFER_VIDEO_LICENSE,
+        ),
+    )
     video_reviewer = models.EmailField(
         null=True, blank=True,
         verbose_name=_("video reviewer"),


### PR DESCRIPTION
Interpolating right there forces a lookup at Django startup time, and
then you never get a translation at the talk submissino form.

I could have used format_lazy from django.utils.text, but that would
require changing the actual string and causing churn on all translation
(which are few at the moment, to be fare). This one-off solution makes
it possible to keep the string untouched.