### PR TITLE
Add 403 template.

### DIFF
--- a/wafer/templates/403.html
+++ b/wafer/templates/403.html
@@ -1,0 +1,8 @@
+{% extends "wafer/base.html" %}
+{% load i18n %}
+{% block content %}
+<h1>{% trans "Forbidden" %}</h1>
+{% blocktrans trimmed %}
+You are not authorized to make this request.
+{% endblocktrans %}
+{% endblock %}


### PR DESCRIPTION
While reviewing #454, we discovered we had no custom 403 page. This adds one.