### PR TITLE
talk submission form: improve display of talk type/track description

### DIFF
--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -29,6 +29,16 @@ def has_field(model, field_name):
         return False
 
 
+class TalkCategorisationWidget(forms.Select):
+
+    class Media:
+        js = ('wafer/talks/talk-categorization.js',)
+
+    def __init__(self, *args, **kwargs):
+        super(TalkCategorisationWidget, self).__init__(*args, **kwargs)
+        self.attrs["class"] = "talk-categorization"
+
+
 class TalkCategorisationField(forms.ModelChoiceField):
     """The categories that talks can be placed into.
     These are always required, if there are any registered.
@@ -36,6 +46,7 @@ class TalkCategorisationField(forms.ModelChoiceField):
     def __init__(self, model, initial=None, empty_label=None, *args, **kwargs):
         super(TalkCategorisationField, self).__init__(
             initial=initial,
+            widget=TalkCategorisationWidget(),
             queryset=model.objects.all(),
             empty_label=None,
             required=True,

--- a/wafer/talks/static/wafer/talks/talk-categorization.js
+++ b/wafer/talks/static/wafer/talks/talk-categorization.js
@@ -1,0 +1,30 @@
+var $ = (jQuery || django.jQuery)
+
+$(document).ready(function() {
+
+    function formatTalkCategorizationResult(item) {
+        var parts = item.text.split(/:\s*/)
+        var name = parts[0]
+        var description = parts[1]
+        return $([
+            "<div>",
+            "<div>",
+            "<strong>",
+            name,
+            "</strong>",
+            "</div>",
+            description,
+            "</div>"
+        ].join(""))
+    }
+
+    function formatTalkCategorizationSelection(item) {
+        return item.text.split(/:\s*/)[0]
+    }
+
+    $('.talk-categorization').select2({
+        templateResult: formatTalkCategorizationResult,
+        templateSelection: formatTalkCategorizationSelection,
+        dropdownAutoWidth: true
+    })
+})

--- a/wafer/templates/wafer/base_form.html
+++ b/wafer/templates/wafer/base_form.html
@@ -1,6 +1,7 @@
 {% extends "wafer/base.html" %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% load static from staticfiles %}
 {% block extra_head %}
   {{ form.media.css }}
 {% endblock %}
@@ -8,5 +9,8 @@
   {% crispy form %}
 {% endblock %}
 {% block extra_foot %}
+  {# this is needed for easy_select2 fields to work outside of the admin app #}
+  <script type="text/javascript" src="{% static 'admin/js/jquery.init.js' %}">
+  </script>
   {{ form.media.js }}
 {% endblock %}


### PR DESCRIPTION
Unless the track description is very short, this makes the <select> box
enormous, often overflowing the screen width. In any cases, good track
names should be self-explanatory so one shouldn't need a description in
the select box items.