### PR TITLE
is_anonymouse can only be used as a property in Django 2+'

### DIFF
--- a/wafer/talks/templatetags/review.py
+++ b/wafer/talks/templatetags/review.py
@@ -11,7 +11,7 @@ def reviewed_badge(user, talk):
     }
 
     review = None
-    if user and not user.is_anonymous():
+    if user and not user.is_anonymous:
         review = talk.reviews.filter(reviewer=user).first()
 
     if review:


### PR DESCRIPTION
Support for calling is_anonymous as a method was removed in Django 2.0