### PR TITLE
Pin jsonfield to before 3.0, so wafer works with older Django versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIRES = [
     'django-registration-redux',
     'djangorestframework<3.11',
     'drf-extensions<0.5',
-    'jsonfield',
+    'jsonfield<3.0.0',
     'pillow',
     'diff-match-patch',
     'pyLibravatar',


### PR DESCRIPTION
Should fix the current build breakages.