### PR TITLE
Bug/missing ics static export

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -313,6 +313,7 @@ BAKERY_VIEWS = (
     'wafer.schedule.views.VenueView',
     'wafer.schedule.views.ScheduleView',
     'wafer.schedule.views.ScheduleXmlView',
+    'wafer.schedule.views.ICalView',
     'wafer.sponsors.views.ShowSponsors',
     'wafer.sponsors.views.ShowPackages',
     'wafer.sponsors.views.SponsorView',


### PR DESCRIPTION
The iCal calendar is not included in the static site export, but arguably should be.