### PR TITLE
wafer.css: provide minimal styling for the schedule

### DIFF
--- a/wafer/static/css/wafer.css
+++ b/wafer/static/css/wafer.css
@@ -73,3 +73,15 @@ ul.profile-links li {
 label.requiredField {
     font-weight: bold;
 }
+
+.wafer_schedule table {
+  border: 1px solid #cccccf;
+  border-collapse: collapse;
+  margin-bottom: 2em;
+}
+
+.wafer_schedule td, .wafer_schedule th {
+  padding: 10px;
+  border: 1px solid #cccccf;
+  vertical-align: top;
+}


### PR DESCRIPTION
Right now, until an app using wafer defines its own CSS for the schedule, it
looks terribly broken. This should be neutral enough and just make the table
look like a table.