### PR TITLE
Ping crispy-forms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 REQUIRES = [
     'Django>=1.11',
-    'django-crispy-forms',
+    'django-crispy-forms<1.9.0',
     'django-nose',
     'django-registration-redux',
     'djangorestframework<3.11',


### PR DESCRIPTION
crispy-forms 1.9.0 breaks Python 2 support, so we need to pin it