### PR TITLE
settings: re-introduce localsettings under wafer/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ nosetests.xml
 /wafer.db
 /media/
 /wafer/static/vendor/
+/wafer/localsettings.py

--- a/wafer/localsettings.py.example
+++ b/wafer/localsettings.py.example
@@ -1,0 +1,2 @@
+DEBUG = True
+ALLOWED_HOSTS = ['*']

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -325,3 +325,8 @@ BAKERY_VIEWS = (
     'wafer.users.views.UsersView',
     'wafer.users.views.ProfileView',
 )
+
+try:
+    from wafer.localsettings import *
+except LoadError:
+    pass


### PR DESCRIPTION
Even though everyone Should™ be using wafer from other apps, it's useful
to run plain wafer, from the wafer sources, to debug issues in isolation.