### PR TITLE
Feature/fix admin scheduletime

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -406,6 +406,9 @@ class SlotAdmin(CompareVersionAdmin):
 
     list_filter = (SlotBlockFilter, SlotStartTimeFilter)
 
+    class Media:
+        js = ('js/scheduledatetime.js',)
+
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
         # Find issues with the slots

--- a/wafer/static/js/scheduledatetime.js
+++ b/wafer/static/js/scheduledatetime.js
@@ -7,7 +7,6 @@
 // unfornately not something we can easily pass in
 
 document.addEventListener("DOMContentLoaded", function() {
-   console.log(window.DateTimeShortcuts);
    // These are for the single admin pages
    window.DateTimeShortcuts.clockHours.end_time_1 = [];
    window.DateTimeShortcuts.clockHours.start_time_1 = [];
@@ -19,7 +18,6 @@ document.addEventListener("DOMContentLoaded", function() {
    // This is for the inline options - we define 30, which is hopefully sane
    for (let inline = 0; inline < 30; inline++) {
       let name = 'form-' + inline + '-end_time_1';
-      console.log('computed name: ' + name);
       window.DateTimeShortcuts.clockHours[name] = [];
       for (let hour = 8; hour <= 20; hour++) {
           let verbose_name = new Date(1970, 1, 1, hour, 0, 0).strftime('%H:%M');

--- a/wafer/static/js/scheduledatetime.js
+++ b/wafer/static/js/scheduledatetime.js
@@ -1,31 +1,29 @@
-// Basic idea from Bojan Mihelac -
-// http://source.mihelac.org/2010/02/19/django-time-widget-custom-time-shortcuts/
+// Override the default setting on the django admin DateTimeShortcut
+// Django 2 nicely does make this overridable, but we need to
+// set it up before the DateTimeShortcuts init is called by
+// window.onload, so we attach it to DOMContentLoaded
+//
+// The names of the input fields are also a bit opaque, and
+// unfornately not something we can easily pass in
 
-// Django imports jQuery into the admin site using noConflict(True)
-// We wrap this in an anonymous function to stick to jQuery's $ idiom
-// and ensure we're using the admin version of jQuery, rather than
-// anything else pulled in
-
-(function($) {
-   var Schedule = {
-      init: function() {
-         time_format = get_format('TIME_INPUT_FORMATS')[0];
-         $(".timelist").each(function(num) {
-            // Clear existing list
-            $( this ).empty();
-            // Fill list with time values
-            for (i=8; i < 20; i++) {
-               var time = new Date(1970,1,1,i,0,0);
-               quickElement("a", quickElement("li", this, ""),
-                  time.strftime(time_format), "href",
-                  "javascript:DateTimeShortcuts.handleClockQuicklink(" + num +
-                  ", " + i + ");");
-            }
-         });
+document.addEventListener("DOMContentLoaded", function() {
+   console.log(window.DateTimeShortcuts);
+   // These are for the single admin pages
+   window.DateTimeShortcuts.clockHours.end_time_1 = [];
+   window.DateTimeShortcuts.clockHours.start_time_1 = [];
+   for (let hour = 8; hour <= 20; hour++) {
+       let verbose_name = new Date(1970, 1, 1, hour, 0, 0).strftime('%H:%M');
+       window.DateTimeShortcuts.clockHours.end_time_1.push([verbose_name, hour])
+       window.DateTimeShortcuts.clockHours.start_time_1.push([verbose_name, hour])
+   }
+   // This is for the inline options - we define 30, which is hopefully sane
+   for (let inline = 0; inline < 30; inline++) {
+      let name = 'form-' + inline + '-end_time_1';
+      console.log('computed name: ' + name);
+      window.DateTimeShortcuts.clockHours[name] = [];
+      for (let hour = 8; hour <= 20; hour++) {
+          let verbose_name = new Date(1970, 1, 1, hour, 0, 0).strftime('%H:%M');
+          window.DateTimeShortcuts.clockHours[name].push([verbose_name, hour])
       }
    }
-
-   // We need to be called after django's DateTimeShortcuts.init, which
-   // is triggered by a load event
-   $( window ).bind('load', Schedule.init);
-}(django.jQuery));
+});


### PR DESCRIPTION
With later Django versions, our earlier approach to replacing the default "6am, noon, 6pm, midnight" range of times in the clock widget doesn't work, as that widget has been extensively rewritten.

This updates that to work with the new Django js code.

I'm not happy with hooking in to DOMContentLoaded to run our code, but I've not come up with a better idea for how to get in before window.onload triggers, which is when the values used are set.