### PR TITLE
Revive GitHub SSO

### DIFF
--- a/wafer/registration/sso.py
+++ b/wafer/registration/sso.py
@@ -27,7 +27,7 @@ def sso(user, desired_username, name, email, profile_fields=None):
     Then log the user in, and return it.
     """
     if not user:
-        if not settings.REGISTRATION_OPEN:
+        if not getattr(settings, 'REGISTRATION_OPEN', True):
             raise SSOError('Account registration is closed')
         user = _create_desired_user(desired_username)
         _configure_user(user, name, email, profile_fields)

--- a/wafer/registration/views.py
+++ b/wafer/registration/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth import login
 from django.contrib.auth.views import redirect_to_login
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.crypto import constant_time_compare, get_random_string
 from django.utils.http import urlencode
 
 from wafer.registration.sso import SSOError, debian_sso, github_sso
@@ -25,17 +26,20 @@ def github_login(request):
         raise Http404()
 
     if 'code' not in request.GET:
+        oauth_state = get_random_string(length=32)
+        request.session['oauth_state'] = oauth_state
         return HttpResponseRedirect(
             'https://github.com/login/oauth/authorize?' + urlencode({
                 'client_id': settings.WAFER_GITHUB_CLIENT_ID,
                 'redirect_uri': request.build_absolute_uri(
                     reverse(github_login)),
                 'scope': 'user:email',
-                'state': request.META['CSRF_COOKIE'],
+                'state': oauth_state,
             }))
 
     try:
-        if request.GET['state'] != request.META['CSRF_COOKIE']:
+        oauth_state = request.session.pop('oauth_state', '')
+        if not constant_time_compare(request.GET['state'], oauth_state):
             raise SSOError('Incorrect state')
 
         user = github_sso(request.GET['code'])


### PR DESCRIPTION
Looks like GitHub SSO has been broken for a while (since Django 1.10).

Django's [BREACH protection](https://code.djangoproject.com/ticket/20869) changed the CSRF token's salting on every use, while keeping the secret part of the token static. That means a simple string comparison, without using Django's (private) CSRF token validation functions, will fail.

Also, GitHub API query-string auth is deprecated, so this migrates away from it.