### PR TITLE
Replace Debian SSO with GitLab SSO

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -26,10 +26,6 @@ Wafer's settings
     The name of the Django cache backend that wafer can use.
     Defaults to ``'wafer_cache'``.
 
-``WAFER_DEBIAN_NM_API_KEY``
-    The API Key for ``nm.debian.org``'s API, used by Debian SSO.
-    Used when ``WAFER_SSO`` contains ``'debian'``.
-
 ``WAFER_DYNAMIC_MENUS``
     A list of functions to call to generate additional menus.
 
@@ -43,6 +39,21 @@ Wafer's settings
     Used when ``WAFER_SSO`` contains ``'github'``.
     If you set this up, they'll provide you with one.
 
+``WAFER_GITLAB_CLIENT_ID``
+    The client ID for GitLab SSO.
+    Used when ``WAFER_SSO`` contains ``'gitlab'``.
+    If you set this up, they'll provide you with one.
+
+``WAFER_GITLAB_CLIENT_SECRET``
+    The secret for GitLab SSO.
+    Used when ``WAFER_SSO`` contains ``'gitlab'``.
+    If you set this up, they'll provide you with one.
+
+``WAFER_GITLAB_HOSTNAME``
+    The hostname of the GitLab instance used for SSO.
+    Defaults to ``gitlab.com``.
+    Used when ``WAFER_SSO`` contains ``'gitlab'``.
+
 ``WAFER_HIDE_LOGIN``
     A boolean flag.
     When ``True``, the login link in the menu is hidden.
@@ -50,7 +61,7 @@ Wafer's settings
 
 ``WAFER_SSO``
     A list of SSO mechanisms in use.
-    Possible options are: ``'debian'``, ``'github'``.
+    Possible options are: ``'github'``, ``'gitlab'``.
 
 ``WAFER_TALK_FORM``
     The form used for talk/event submission.

--- a/wafer/registration/sso.py
+++ b/wafer/registration/sso.py
@@ -27,7 +27,7 @@ def sso(user, desired_username, name, email, profile_fields=None):
     Then log the user in, and return it.
     """
     if not user:
-        if not settings.REGISTRATION_OPEN:
+        if not getattr(settings, 'REGISTRATION_OPEN', True):
             raise SSOError('Account registration is closed')
         user = _create_desired_user(desired_username)
         _configure_user(user, name, email, profile_fields)

--- a/wafer/registration/templates/registration/login.html
+++ b/wafer/registration/templates/registration/login.html
@@ -24,8 +24,8 @@
                 {% if 'github' in WAFER_SSO %}
                 <li><a href="{% wafer_sso_url 'github' %}">GitHub</a></li>
                 {% endif %}
-                {% if 'debian' in WAFER_SSO %}
-                <li><a href="{% wafer_sso_url 'debian' %}">Debian SSO</a></li>
+                {% if 'gitlab' in WAFER_SSO %}
+                <li><a href="{% wafer_sso_url 'gitlab' %}">GitLab</a></li>
                 {% endif %}
             </ul>
             {% endif %}

--- a/wafer/registration/urls.py
+++ b/wafer/registration/urls.py
@@ -1,13 +1,14 @@
 from django.conf.urls import include, url
 
-from wafer.registration.views import debian_login, github_login, redirect_profile
+from wafer.registration.views import (
+    github_login, gitlab_login, redirect_profile)
 
 
 urlpatterns = [
     url(r'^profile/$', redirect_profile),
 
     url(r'^github-login/$', github_login),
-    url(r'^debian-login/$', debian_login),
+    url(r'^gitlab-login/$', gitlab_login),
 
     url(r'', include('registration.backends.default.urls')),
     url(r'', include('registration.auth_urls')),

--- a/wafer/registration/views.py
+++ b/wafer/registration/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth import login
 from django.contrib.auth.views import redirect_to_login
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.crypto import constant_time_compare, get_random_string
 from django.utils.http import urlencode
 
 from wafer.registration.sso import SSOError, debian_sso, github_sso
@@ -25,17 +26,20 @@ def github_login(request):
         raise Http404()
 
     if 'code' not in request.GET:
+        oauth_state = get_random_string(length=32)
+        request.session['oauth_state'] = oauth_state
         return HttpResponseRedirect(
             'https://github.com/login/oauth/authorize?' + urlencode({
                 'client_id': settings.WAFER_GITHUB_CLIENT_ID,
                 'redirect_uri': request.build_absolute_uri(
                     reverse(github_login)),
                 'scope': 'user:email',
-                'state': request.META['CSRF_COOKIE'],
+                'state': oauth_state,
             }))
 
     try:
-        if request.GET['state'] != request.META['CSRF_COOKIE']:
+        oauth_state = request.session.pop('oauth_state', '')
+        if not constant_time_compare(request.GET['state'], oauth_state):
             raise SSOError('Incorrect state')
 
         user = github_sso(request.GET['code'])

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -242,23 +242,17 @@ WAFER_DYNAMIC_MENUS = (
 # Enabled SSO mechanims:
 WAFER_SSO = (
     # 'github',
-    # 'debian',
+    # 'gitlab',
 )
 
 # Log in with GitHub:
 # WAFER_GITHUB_CLIENT_ID = 'register on github'
 # WAFER_GITHUB_CLIENT_SECRET = 'to get these secrets'
 
-# Log in with Debian SSO:
-# Requires some Apache config:
-# SSLCACertificateFile /srv/sso.debian.org/etc/debsso.crt
-# SSLCARevocationCheck chain
-# SSLCARevocationFile /srv/sso.debian.org/etc/debsso.crl
-# <Location /accounts/debian-login/>
-#     SSLOptions +StdEnvVars
-#     SSLVerifyClient optional
-# </Location>
-# WAFER_DEBIAN_NM_API_KEY = 'obtain one from https://nm.debian.org/apikeys/'
+# Log in with GitLab:
+# WAFER_GITLAB_HOSTNAME = 'gitlab.com'
+# WAFER_GITLAB_CLIENT_ID = 'register on github'
+# WAFER_GITLAB_CLIENT_SECRET = 'to get these secrets'
 
 # Set this to true to disable the login button on the navigation toolbar
 WAFER_HIDE_LOGIN = False


### PR DESCRIPTION
Debian's client-certificate based SSO mechanism is being retired,
replaced by SSO through Salsa, a GitLab instance.

https://lists.debian.org/debian-project/2020/04/msg00000.html

This is very similar, but not 100% identical to the GitHub implementation.

This branch is built on #528. The relevant change is in the the last commit.