### PR TITLE
Refuse SSO account creation with duplicate email

### DIFF
--- a/wafer/registration/sso.py
+++ b/wafer/registration/sso.py
@@ -29,6 +29,11 @@ def sso(user, desired_username, name, email, profile_fields=None):
     if not user:
         if not settings.REGISTRATION_OPEN:
             raise SSOError('Account registration is closed')
+
+        if get_user_model().objects.filter(email=email).exists():
+            raise SSOError(
+                "An account already exists for {} that doesn't use SSO. "
+                "Refusing to create a second account.".format(email))
         user = _create_desired_user(desired_username)
         _configure_user(user, name, email, profile_fields)
 


### PR DESCRIPTION
If there is already a user with that email address, don't create a new user during SSO.

Don't SSO into the existing account, either, because the user hasn't previously authorized us to.

Debian has seen several users end up with duplicate accounts like this, because they signed up through the password-based flow, and then SSOed later.