### PR TITLE
Specify minimum version of drf-extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     'django-nose',
     'django-registration-redux',
     'djangorestframework',
-    'drf-extensions',
+    'drf-extensions>=0.5.0',
     'jsonfield',
     'pillow',
     'diff-match-patch',


### PR DESCRIPTION
In d4d69fe8e0e69f181578d4d2779063030bc3a81b the router call was changed
in a way that is no longer compatible with drf-extensions 0.4