### PR TITLE
Add a setting to make talks visible to authenticated users

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -261,6 +261,9 @@ WAFER_HIDE_LOGIN = False
 # Set this to False to disable talk submissions
 WAFER_TALKS_OPEN = True
 
+# Talk submissions are visible to all attendees
+WAFER_TALKS_ALL_VISIBLE = False
+
 # The form used for talk submission
 WAFER_TALK_FORM = 'wafer.talks.forms.TalkForm'
 

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -325,10 +325,14 @@ class Talk(models.Model):
             return True
         if self.accepted or self.cancelled:
             return True
+        if user.is_authenticated and getattr(settings, 'WAFER_TALKS_ALL_VISIBLE', False):
+            return True
         return False
 
     @classmethod
     def can_view_all(cls, user):
+        if user.is_authenticated and getattr(settings, 'WAFER_TALKS_ALL_VISIBLE', False):
+            return True
         return user.has_perm('talks.view_all_talks')
 
     def can_edit(self, user):


### PR DESCRIPTION
In the context of our internal conference, authentication is only possible for employees from our domain, and we want them to be able to see all the proposed talks. This patch is needed to achieve this at minimum cost.