### PR TITLE
WIP: Feature/allow default groups

### DIFF
--- a/wafer/management/commands/wafer_add_default_groups.py
+++ b/wafer/management/commands/wafer_add_default_groups.py
@@ -14,6 +14,9 @@ class Command(BaseCommand):
             ('pages', 'change_page'), ('pages', 'add_file'),
             ('pages', 'delete_file'), ('pages', 'change_file'),
         ),
+        'Page Content Editors': (
+            ('pages', 'change_page'),
+        ),
         'Talk Mentors': (
             ('talks', 'change_talk'), ('talks', 'view_all_talks'),
             ('talks', 'edit_private_notes'),
@@ -22,6 +25,9 @@ class Command(BaseCommand):
             ('talks', 'view_all_talks'),
             ('talks', 'edit_private_notes'),
             ('talks', 'add_review'),
+        ),
+        'View All Talks': (
+            ('talks', 'view_all_talks'),
         ),
         'Registration': (),
     }

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -319,3 +319,6 @@ BAKERY_VIEWS = (
     'wafer.users.views.UsersView',
     'wafer.users.views.ProfileView',
 )
+
+# Groups to which new users should be automatically added.
+WAFER_DEFAULT_GROUPS = ()


### PR DESCRIPTION
This is an alternative take on solving the problem raised in #537 , allowing a set of default groups to which new users will be added.

I like the general idea, but I'm not convinced that specifying the default groups in the settings file is the right approach - it feels like something that should be managed as part of the admin.

Thoughts and/or opinions?