### PR TITLE
schedule editor: give the page a title

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -1,6 +1,7 @@
 {% extends "wafer/base.html" %}
 {% load i18n %}
 {% load static %}
+{% block title %}Edit Schedule - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <div class="row">
   <div class="col-md-12">


### PR DESCRIPTION
This makes it easier to find the tab where I am editing the schedule.