### PR TITLE
Filter nested TalkUrls

### DIFF
--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -717,6 +717,16 @@ class TalkUrlsViewSetTests(TestCase):
             self.mk_result(url_a), self.mk_result(url_b),
         ])
 
+    def test_list_talk_urls_nested_filtering(self):
+        talk_a = create_talk("Talk", ACCEPTED, "author")
+        talk_b = create_talk("Talk 2", ACCEPTED, "author 2")
+        url_a = TalkUrl.objects.create(
+            talk=talk_a, url="http://a.example.com/", description="video")
+        url_b = TalkUrl.objects.create(
+            talk=talk_b, url="http://b.example.com/", description="slides")
+        response = self.client.get('/talks/api/talks/%d/urls/' % talk_a.talk_id)
+        self.assertEqual(response.data['results'], [self.mk_result(url_a)])
+
     def test_retrieve_talk_url(self):
         talk = create_talk("Talk A", ACCEPTED, "author_a")
         url = TalkUrl.objects.create(

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -256,7 +256,7 @@ class TalkTypesView(BuildableListView):
     build_path = 'talks/types/index.html'
 
 
-class TalksViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
+class TalksViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     """API endpoint that allows talks to be viewed or edited."""
     queryset = Talk.objects.none()  # Needed for the REST Permissions
     serializer_class = TalkSerializer
@@ -291,7 +291,7 @@ class TalkExistsPermission(BasePermission):
         return True
 
 
-class TalkUrlsViewSet(viewsets.ModelViewSet, NestedViewSetMixin):
+class TalkUrlsViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     """API endpoint that allows talks to be viewed or edited."""
     queryset = TalkUrl.objects.all().order_by('id')
     serializer_class = TalkUrlSerializer


### PR DESCRIPTION
They weren't being filtered in the nested router, `/talks/api/talks/7/urls` would return all URLs, not just the URLs for talk 7.

Seems to have been caused by an inheritance order bug.