### PR TITLE
Add url field to ical export

### DIFF
--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -1521,6 +1521,8 @@ class NonHTMLViewTests(TestCase):
         event = calendar.walk(name='VEVENT')[0]
         self.assertEqual(event['dtstart'].params['value'], 'DATE-TIME')
         self.assertEqual(event['dtstart'].dt, D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc))
+        # Check that we have the page slug in the ical event
+        self.assertTrue('/test0/' in event['url'])
 
 
 class ScheduleItemViewSetTests(TestCase):

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -401,6 +401,7 @@ class ICalView(View, BuildableMixin):
             sched_event.add('duration', datetime.timedelta(minutes=item.get_duration_minutes()))
             sched_event.add('class', 'PUBLIC')
             sched_event.add('uid', '%s@%s' % (item.pk, site.domain))
+            sched_event.add('url', item.get_url())
             calendar.add_component(sched_event)
         response = HttpResponse(calendar.to_ical(), content_type="text/calendar")
         response['Content-Disposition'] = 'attachment; filename=schedule.ics'


### PR DESCRIPTION
We don't include the URL to the event in the iCAL export, and we should.