### PR TITLE
Feature/rework Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
    - "3.6"
    - "3.7"
    - "3.8"
-   - "3.9"
+   - "3.9-dev"
 env:
    - DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
    - DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
@@ -28,13 +28,13 @@ matrix:
         env: DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
       - python: "3.8"
         env: DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
-      - python: "3.9"
+      - python: "3.9-dev"
         env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
-      - python: "3.9"
+      - python: "3.9-dev"
         env: DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
-      - python: "3.9"
+      - python: "3.9-dev"
         env: DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
-      - python: "3.9"
+      - python: "3.9-dev"
         env: DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
 
    allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
    - DJANGO='django>=2.2,<3.0' TESTDB=postgres
    - DJANGO='django>=3.0,<3.1.0' TESTDB=sqlite
    - DJANGO='django>=3.0,<3.1.0' TESTDB=postgres
-   - DJANGO='django>=3.1,<3.2.0' TESTDB=sqlite
-   - DJANGO='django>=3.1,<3.2.0' TESTDB=postgres
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 dist: xenial
 python:
-   - "3.5"
    - "3.6"
    - "3.7"
    - "3.8"
@@ -20,14 +19,6 @@ env:
 
 matrix:
    exclude:
-      - python: "3.5"
-        env: DJANGO='django>=3.0,<3.1.0' TESTDB=sqlite
-      - python: "3.5"
-        env: DJANGO='django>=3.0,<3.1.0' TESTDB=postgres
-      - python: "3.5"
-        env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
-      - python: "3.5"
-        env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
       - python: "3.8"
         env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
       - python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
    - "3.6"
    - "3.7"
    - "3.8"
+   - "3.9"
 env:
    - DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
    - DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
@@ -14,6 +15,8 @@ env:
    - DJANGO='django>=2.2,<3.0' TESTDB=postgres
    - DJANGO='django>=3.0,<3.1.0' TESTDB=sqlite
    - DJANGO='django>=3.0,<3.1.0' TESTDB=postgres
+   - DJANGO='django>=3.1,<3.2.0' TESTDB=sqlite
+   - DJANGO='django>=3.1,<3.2.0' TESTDB=postgres
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
@@ -26,6 +29,14 @@ matrix:
       - python: "3.8"
         env: DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
       - python: "3.8"
+        env: DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
+      - python: "3.9"
+        env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
+      - python: "3.9"
+        env: DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
+      - python: "3.9"
+        env: DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
+      - python: "3.9"
         env: DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
 
    allow_failures:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Supported versions
 ==================
 
-Wafer supports Django 2.0-3.0 and Python 3.5 onwards.
+Wafer supports Django 2.0-3.0 and Python 3.6 onwards.
 
 Requirements
 ============

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Python 3.5 is EOL, so we now longer need to test on it, and can drop the promise of supporting it.