### PR TITLE
Bugfix/fix missing pentabarf end

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -7,7 +7,7 @@
         {% with page=schedule_pages|first %}
           <start>{{ page.block.start_time|date:"Y-m-d" }}</start>
         {% endwith %}
-        {% with day=schedule_pages|last %}
+        {% with page=schedule_pages|last %}
           <end>{{ page.block.end_time|date:"Y-m-d" }}</end>
         {% endwith %}
         <days>{{ schedule_pages|length }}</days>

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -1469,6 +1469,8 @@ class NonHTMLViewTests(TestCase):
         start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
         start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
         start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
+        start6 = D.datetime(2013, 9, 23, 14, 0, 0, tzinfo=timezone.utc)
+        end6 = D.datetime(2013, 9, 23, 15, 0, 0, tzinfo=timezone.utc)
 
         slots = []
 
@@ -1476,6 +1478,7 @@ class NonHTMLViewTests(TestCase):
         slots.append(Slot.objects.create(start_time=start2, end_time=start3))
         slots.append(Slot.objects.create(start_time=start3, end_time=start4))
         slots.append(Slot.objects.create(start_time=start4, end_time=start5))
+        slots.append(Slot.objects.create(start_time=start6, end_time=end6))
 
         pages = make_pages(8)
         venues = [venue1, venue2] * 4

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -1495,6 +1495,15 @@ class NonHTMLViewTests(TestCase):
         self.assertEqual(parsed[0].tag, 'conference')
         self.assertEqual(parsed[1].tag, 'day')
 
+        # Various tools expect 'start' and 'end' values, so
+        # check we have those
+        conf = parsed[0]
+        self.assertEqual('title', conf[0].tag)
+        self.assertEqual('start', conf[1].tag)
+        self.assertEqual('end', conf[2].tag)
+        self.assertEqual('2013-09-22', conf[1].text)
+        self.assertEqual('2013-09-23', conf[2].text)
+
         day = parsed[1]
         self.assertIn(('date', '2013-09-22'), day.items())
         self.assertEqual(day[0].tag, 'room')


### PR DESCRIPTION
Various tooling breaks if pentabarf doesn't have correct start and end values, and a typo in the conversion to the block based schedule has left that broken for a while.