### PR TITLE
Use named arguments in translatable strings

### DIFF
--- a/wafer/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wafer/locale/pt_BR/LC_MESSAGES/django.po
@@ -519,8 +519,8 @@ msgstr "Erros de validação"
 
 #: wafer/schedule/templates/wafer.schedule/edit_schedule.html:22
 #: wafer/schedule/templates/wafer.schedule/edit_schedule.html:27
-msgid "(Block"
-msgstr "Bloco"
+msgid "(Block %(block_id)s)"
+msgstr "(Bloco %(block_id)s)"
 
 #: wafer/schedule/templates/wafer.schedule/edit_schedule.html:32
 msgid "Schedule Editor"
@@ -951,8 +951,8 @@ msgstr "Comentários sobre a proposta (markdown)"
 
 #: wafer/talks/models.py:375
 #, python-format
-msgid "Review of %s by %s (%s)"
-msgstr "Revisão de %s por %s (%s)"
+msgid "Review of %(title)s by %(reviewer)s (%(average_score)s)"
+msgstr "Revisão de %(title)s por %(reviewer)s (%(average_score)s)"
 
 #: wafer/talks/models.py:392
 msgid "review"
@@ -972,8 +972,8 @@ msgstr "aspectos da revisão"
 
 #: wafer/talks/models.py:420
 #, python-format
-msgid "Review of %s by %s on %s: %i"
-msgstr "Revisão de %s por %s em %s: %i"
+msgid "Review of %(title)s by %(reviewer)s on %(aspect)s: %(score)i"
+msgstr "Revisão de %(title)s por %(reviewer)s em %(aspect)s: %(score)i"
 
 #: wafer/talks/models.py:425
 msgid "score"

--- a/wafer/locale/ru/LC_MESSAGES/django.po
+++ b/wafer/locale/ru/LC_MESSAGES/django.po
@@ -698,7 +698,7 @@ msgid "Review Talk"
 msgstr ""
 
 #, python-format
-msgid "Review of %s by %s (%s)"
+msgid "Review of %(title)s by %(reviewer)s (%(average_score)s)"
 msgstr ""
 
 msgid "Reviewed"

--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -20,12 +20,12 @@
     <div class="dropdown float-right">
       <button class="btn btn-secondary dropdown-toggle" type="button"
               data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-        {{ this_block }} {% trans "(Block" %} {{ this_block.id }})
+        {{ this_block }} {% blocktrans with block_id=this_block.id %}(Block {{ block_id }}){% endblocktrans %}
       </button>
       <div class="dropdown-menu">
         {% for sched_block in all_blocks %}
           <a class="dropdown-item" href="{% url 'admin:schedule_editor' sched_block.id %}">
-            {{ sched_block }} {% trans "(Block" %} {{ sched_block.id }})
+             {{ sched_block }} {% blocktrans with block_id=sched_block.id %}(Block {{ block_id }}){% endblocktrans %}
           </a>
         {% endfor %}
       </div>

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -375,8 +375,10 @@ class Review(models.Model):
         help_text=_("Comments on the proposal (markdown)"))
 
     def __str__(self):
-        return _(u'Review of %s by %s (%s)') % (
-            self.talk.title, self.reviewer, self.avg_score)
+        return _(u'Review of %(title)s by %(reviewer)s (%(average_score)s)') % {
+                'title': self.talk.title,
+                'reviewer': self.reviewer,
+                'average_score': self.avg_score}
 
     @property
     def avg_score(self):
@@ -420,8 +422,11 @@ class Score(models.Model):
 
     def __str__(self):
         review = self.review
-        return _(u'Review of %s by %s on %s: %i') % (
-            review.reviewer, review.talk.title, self.aspect.name, self.value)
+        return _(u'Review of %(title)s by %(reviewer)s on %(aspect)s: %(score)i') % {
+                'title': review.talk.title,
+                'reviewer': review.reviewer,
+                'aspect': self.aspect.name,
+                'score': self.value}
 
     class Meta:
         unique_together = (('review', 'aspect'),)


### PR DESCRIPTION
manage.py makemessages justifiably complains about strings with multiple unnamed arguments as being difficult to translate, so we should not do that.