### PR TITLE
Feature/rework django test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ python:
    - "3.8"
    - "3.9-dev"
 env:
-   - DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
-   - DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
-   - DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
-   - DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
    - DJANGO='django>=2.2,<3.0' TESTDB=sqlite
    - DJANGO='django>=2.2,<3.0' TESTDB=postgres
    - DJANGO='django>=3.0,<3.1.0' TESTDB=sqlite
@@ -19,24 +15,6 @@ env:
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
 matrix:
-   exclude:
-      - python: "3.8"
-        env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
-      - python: "3.8"
-        env: DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
-      - python: "3.8"
-        env: DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
-      - python: "3.8"
-        env: DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
-      - python: "3.9-dev"
-        env: DJANGO='django>=2.0,<2.1.0' TESTDB=sqlite
-      - python: "3.9-dev"
-        env: DJANGO='django>=2.0,<2.1.0' TESTDB=postgres
-      - python: "3.9-dev"
-        env: DJANGO='django>=2.1,<2.2.0' TESTDB=sqlite
-      - python: "3.9-dev"
-        env: DJANGO='django>=2.1,<2.2.0' TESTDB=postgres
-
    allow_failures:
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,15 @@ env:
    - DJANGO='django>=2.2,<3.0' TESTDB=postgres
    - DJANGO='django>=3.0,<3.1.0' TESTDB=sqlite
    - DJANGO='django>=3.0,<3.1.0' TESTDB=postgres
+   - DJANGO='django>=3.1,<3.2.0' TESTDB=sqlite
+   - DJANGO='django>=3.1,<3.2.0' TESTDB=postgres
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
    - DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
 
 matrix:
    allow_failures:
+      - env: DJANGO='django>=3.1,<3.2.0' TESTDB=sqlite
+      - env: DJANGO='django>=3.1,<3.2.0' TESTDB=postgres
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=postgres
       - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' TESTDB=sqlite
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_install:
    - if [ "$TESTDB" = "postgres" ]; then pip install -q psycopg2 ; fi
 # command to install dependencies,
 install:
-   # Install the right version of Django first
-   - pip install "$DJANGO"
    - pip install -r requirements.txt -r requirements-dev.txt
+   # Install the right version of Django after we've installed wafer's version
+   - pip install "$DJANGO"
 # command to run tests
 script: NOSE_WITH_COVERAGE=1 NOSE_COVER_PACKAGE=wafer python manage.py test

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=2.0, <3.0',
+    'Django>=2.2,<3.1',
     'django-crispy-forms',
     'django-nose',
     'django-registration-redux',


### PR DESCRIPTION
This drops testing against EOL Django versions (namely 2.0 and 2.1). It also fixes the testing against currently unsupported Django versions, which broke when we added an upper limit to the Django version we support.