### PR TITLE
Feature/group speakers by talk type

### DIFF
--- a/wafer/talks/templates/wafer.talks/speakers.html
+++ b/wafer/talks/templates/wafer.talks/speakers.html
@@ -10,9 +10,9 @@
       <h1>{% blocktrans %}{{ talk_type }} Speakers{% endblocktrans %}</h1>
     {% endif %}
     {% if talk_type is None %}
-      <div class="container" class="speakers-list">
+      <div class="container speakers-list">
     {% else %}
-      <div class="container" class="{{talk_type|slugify}-speakers-list">
+      <div class="container {{talk_type|slugify}}-speakers-list">
     {% endif %}
       {% for row in type_rows %}
         <div class="row">

--- a/wafer/talks/templates/wafer.talks/speakers.html
+++ b/wafer/talks/templates/wafer.talks/speakers.html
@@ -3,26 +3,32 @@
 {% block title %}{% trans "Speakers" %} - {{ WAFER_CONFERENCE_NAME }}{% endblock %}
 {% block content %}
 <section class="wafer wafer-speakers">
-  <h1>{% trans 'Speakers' %}</h1>
-  <div class="container">
-    {% for row in speaker_rows %}
-      <div class="row">
-        {% for user_profile in row %}
-          <div class="col-md-3">
-            <div class="wafer-speakers-logo">
-              <a href="{% url 'wafer_user_profile' username=user_profile.user.username %}">
-                <img class="thumbnail mx-auto" src="{{ user_profile.avatar_url }}">
-              </a>
+  {% for talk_type, type_rows in speaker_rows.items %}
+    {% if talk_type is None %}
+      <h1>{% trans 'Speakers' %}</h1>
+    {% else %}
+      <h1>{{ talk_type }}</h1>
+    {% endif %}
+    <div class="container">
+      {% for row in type_rows %}
+        <div class="row">
+          {% for user_profile in row %}
+            <div class="col-md-3">
+              <div class="wafer-speakers-logo">
+                <a href="{% url 'wafer_user_profile' username=user_profile.user.username %}">
+                  <img class="thumbnail mx-auto" src="{{ user_profile.avatar_url }}">
+                </a>
+              </div>
+              <div class="wafer-speakers-name">
+                <a href="{% url 'wafer_user_profile' username=user_profile.user.username %}">
+                  {{ user_profile.display_name }}
+                </a>
+              </div>
             </div>
-            <div class="wafer-speakers-name">
-              <a href="{% url 'wafer_user_profile' username=user_profile.user.username %}">
-                {{ user_profile.display_name }}
-              </a>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-    {% endfor %}
-  </div>
+          {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endfor %}
 </section>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/speakers.html
+++ b/wafer/talks/templates/wafer.talks/speakers.html
@@ -7,9 +7,13 @@
     {% if talk_type is None %}
       <h1>{% trans 'Speakers' %}</h1>
     {% else %}
-      <h1>{{ talk_type }}</h1>
+      <h1>{% blocktrans %}{{ talk_type }} Speakers{% endblocktrans %}</h1>
     {% endif %}
-    <div class="container">
+    {% if talk_type is None %}
+      <div class="container" class="speakers-list">
+    {% else %}
+      <div class="container" class="{{talk_type|slugify}-speakers-list">
+    {% endif %}
       {% for row in type_rows %}
         <div class="row">
           {% for user_profile in row %}

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -399,7 +399,7 @@ class SpeakerTests(TestCase):
         response = self.client.get(
             reverse('wafer_talks_speakers'))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["speaker_rows"], [
+        self.assertEqual(response.context["speaker_rows"][None], [
             profiles[start:end] for start, end in expected_rows
         ])
 

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -455,7 +455,7 @@ class SpeakerTests(TestCase):
         self.assertEqual(response.context["speaker_rows"]['Talk'],
                          [[user_d.userprofile, user_e.userprofile]])
         self.assertEqual(response.context["speaker_rows"]['Keynote'],
-                         [[user_f.userprofile, user_e.userprofile]])
+                         [[user_e.userprofile, user_f.userprofile]])
 
         # Because of how assertHTMLEquals works, we can't combine these
         # unless we include the surrounding <section>, which becomes
@@ -504,18 +504,6 @@ class SpeakerTests(TestCase):
             '  <div class="row">',
             '    <div class="col-md-3">',
             '      <div class="wafer-speakers-logo">',
-            '        <a href="/users/%s/">' % user_f.username,
-            '          <img class="thumbnail mx-auto" src="%s">' % img_f,
-            '        </a>',
-            '      </div>',
-            '      <div class="wafer-speakers-name">',
-            '        <a href="/users/%s/">' % user_f.username,
-            '          author_f',
-            '        </a>',
-            '      </div>',
-            '    </div>',
-            '    <div class="col-md-3">',
-            '      <div class="wafer-speakers-logo">',
             '        <a href="/users/%s/">' % user_e.username,
             '          <img class="thumbnail mx-auto" src="%s">' % img_e,
             '        </a>',
@@ -523,6 +511,18 @@ class SpeakerTests(TestCase):
             '      <div class="wafer-speakers-name">',
             '        <a href="/users/%s/">' % user_e.username,
             '          author_e',
+            '        </a>',
+            '      </div>',
+            '    </div>',
+            '    <div class="col-md-3">',
+            '      <div class="wafer-speakers-logo">',
+            '        <a href="/users/%s/">' % user_f.username,
+            '          <img class="thumbnail mx-auto" src="%s">' % img_f,
+            '        </a>',
+            '      </div>',
+            '      <div class="wafer-speakers-name">',
+            '        <a href="/users/%s/">' % user_f.username,
+            '          author_f',
             '        </a>',
             '      </div>',
             '    </div>',

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -243,7 +243,8 @@ class Speakers(BuildableListView):
             user__talks__status='A').distinct().prefetch_related(
             'user').order_by('user__talks__talk_type',
                              'user__first_name',
-                             'user__last_name').annotate(
+                             'user__last_name',
+                             'user__username').annotate(
             talk_type=F('user__talks__talk_type__name'))
         bytype = groupby(speakers, lambda x: x.talk_type)
         context['speaker_rows'] = {}

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -241,7 +241,7 @@ class Speakers(BuildableListView):
         context = super(Speakers, self).get_context_data(**kwargs)
         speakers = UserProfile.objects.filter(
             user__talks__status='A').distinct().prefetch_related(
-            'user').order_by('user__talks__talk_type__name',
+            'user').order_by('user__talks__talk_type',
                              'user__first_name',
                              'user__last_name').annotate(
             talk_type=F('user__talks__talk_type__name'))

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -248,7 +248,7 @@ class Speakers(BuildableListView):
         bytype = groupby(speakers, lambda x: x.talk_type)
         context['speaker_rows'] = {}
         for talk_type, type_speakers in bytype:
-            context["speaker_rows"][talk_type] = self._by_row(type_speakers, 4)
+            context["speaker_rows"][talk_type] = self._by_row(list(type_speakers), 4)
         return context
 
 


### PR DESCRIPTION
Following a discussion in during the PyCon ZA 2020 sprints, this groups the speakers on the speaker list by talk type, rather than purely alphabetically - this makes it possible to highlight / emphasis keynote speakers or other such adjustments

This does mean speakers with multiple accepted submissions are listed in each section - this is probably fine.

It also simplifies fixing #377, as adding a "hide talk type" can now just hide the suitable list, without more complex logic.