### PR TITLE
Don't hard-code the list of languages

### DIFF
--- a/utils/update_i18n_files.sh
+++ b/utils/update_i18n_files.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 # Update the langauge files and main django.pot file
-LANGS="pt_BR ru"
 
 base=$(dirname $0)
 cd $base/..
 
-for lang in $LANGS; do
+for cand in wafer/locale/*; do
+   if [ ! -d $cand ]; then
+      continue
+   fi
+   lang=$(basename $cand)
    ./manage.py makemessages -l $lang
 done
 ./manage.py makemessages --keep-pot


### PR DESCRIPTION
It's much better to run the script for all languages present, rather
than keeping a separate list.