### PR TITLE
Bugfix/update django checks

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -45,7 +45,7 @@ jobs:
         pip install django~=${{ matrix.django-version }}
       if: matrix.django-version != 'main'
     - name: Install Django Main
-      continue-on-error: matrix.django-version == 'main'
+      continue-on-error: ${{ matrix.django-version == 'main' }}
       run: |
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'
@@ -83,7 +83,7 @@ jobs:
         pip install django~=${{ matrix.django-version }}
       if: matrix.django-version != 'main'
     - name: Install Django Main
-      continue-on-error: matrix.django-version == 'main'
+      continue-on-error: ${{ matrix.django-version == 'main' }}
       run: |
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -44,7 +44,8 @@ jobs:
       run: |
         pip install django~=${{ matrix.django-version }}
       if: matrix.django-version != 'main'
-    - name: Install Django Master
+    - name: Install Django Main
+      continue-on-error: matrix.django-version == 'main'
       run: |
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'
@@ -81,7 +82,8 @@ jobs:
       run: |
         pip install django~=${{ matrix.django-version }}
       if: matrix.django-version != 'main'
-    - name: Install Django Master
+    - name: Install Django Main
+      continue-on-error: matrix.django-version == 'main'
       run: |
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,12 +22,12 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'master' }} )
+    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }} )
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: ['2.2.0', '3.0.0', '3.1.0', 'master']
+        django-version: ['2.2.0', '3.0.0', '3.1.0', 'main']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'master' }}
+      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }}
       run: |
         python -m pip install --upgrade pip
         pip install psycopg2
@@ -43,13 +43,13 @@ jobs:
     - name: Install Django Release
       run: |
         pip install django~=${{ matrix.django-version }}
-      if: matrix.django-version != 'master'
+      if: matrix.django-version != 'main'
     - name: Install Django Master
       run: |
-        pip install 'https://github.com/django/django/archive/master.tar.gz'
-      if: matrix.django-version == 'master'
+        pip install 'https://github.com/django/django/archive/main.tar.gz'
+      if: matrix.django-version == 'main'
     - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'master' }}
+      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }}
       env:
         TESTDB: postgres
       run: |
@@ -59,12 +59,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'master' }} )
+    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }} )
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: ['2.2.0', '3.0.0', '3.1.0', 'master']
+        django-version: ['2.2.0', '3.0.0', '3.1.0', 'main']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -72,7 +72,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'master' }}
+      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
@@ -80,12 +80,12 @@ jobs:
     - name: Install Django Release
       run: |
         pip install django~=${{ matrix.django-version }}
-      if: matrix.django-version != 'master'
+      if: matrix.django-version != 'main'
     - name: Install Django Master
       run: |
-        pip install 'https://github.com/django/django/archive/master.tar.gz'
-      if: matrix.django-version == 'master'
+        pip install 'https://github.com/django/django/archive/main.tar.gz'
+      if: matrix.django-version == 'main'
     - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'master' }}
+      continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }}
       run: |
         NOSE_WITH_COVERAGE=1 NOSE_COVER_PACKAGE=wafer python manage.py test


### PR DESCRIPTION
This updates the workflow file after Django's renaming of the master branch to 'main'

This also allows the installation of the django main branch to fail as a quick workaround for the failures caused by the changes to the required minimum python version, until we get around to relooking at our test matrix.