### PR TITLE
Handle PermissionDenied when building Users

### DIFF
--- a/wafer/users/views.py
+++ b/wafer/users/views.py
@@ -66,14 +66,14 @@ class ProfileView(Hide404Mixin, BuildableDetailView):
         return reverse('wafer_user_profile', args=(obj.username,))
 
     def build_object(self, obj):
-        """Override django-bakery to skip profiles that raise 404"""
+        """Override django-bakery to skip profiles that raise 403"""
         try:
             build_path = self.get_build_path(obj)
             self.request = self.create_request(build_path)
             self.request.user = AnonymousUser()
             self.set_kwargs(obj)
             self.build_file(build_path, self.get_content())
-        except Http404:
+        except PermissionDenied:
             # cleanup directory
             self.unbuild_object(obj)
 


### PR DESCRIPTION
We hide all user pages behind 403, when WAFER_PUBLIC_ATTENDEE_LIST is
disabled, to avoid information leakage
(d3ccc4cab2c7b0bd63510b0c32ecbc66d3beb527)