### PR TITLE
Disallow problematic usernames

### DIFF
--- a/wafer/registration/forms.py
+++ b/wafer/registration/forms.py
@@ -4,15 +4,17 @@ from django.utils.translation import ugettext as _
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Hidden, Submit
+from registration.forms import RegistrationForm
 
 
-class RegistrationFormHelper(FormHelper):
-    form_action = reverse('registration_register')
-    include_media = False
 
-    def __init__(self, request, *args, **kwargs):
-        super(RegistrationFormHelper, self).__init__(*args, **kwargs)
-        self.add_input(Submit('submit', _('Sign up')))
+class WaferRegistrationForm(RegistrationForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.include_media = False
+        self.helper.form_action = reverse('registration_register')
+        self.helper.add_input(Submit('submit', _('Sign up')))
 
 
 class LoginFormHelper(FormHelper):

--- a/wafer/registration/forms.py
+++ b/wafer/registration/forms.py
@@ -6,6 +6,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Hidden, Submit
 from registration.forms import RegistrationForm
 
+from wafer.registration.validators import validate_username
 
 
 class WaferRegistrationForm(RegistrationForm):
@@ -15,6 +16,11 @@ class WaferRegistrationForm(RegistrationForm):
         self.helper.include_media = False
         self.helper.form_action = reverse('registration_register')
         self.helper.add_input(Submit('submit', _('Sign up')))
+
+    def clean_username(self):
+        username = self.cleaned_data['username']
+        validate_username(username)
+        return username
 
 
 class LoginFormHelper(FormHelper):

--- a/wafer/registration/templates/registration/registration_form.html
+++ b/wafer/registration/templates/registration/registration_form.html
@@ -1,9 +1,7 @@
 {% extends 'wafer/base_form.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% load wafer_crispy %}
 {% block content %}
 <h1>{% trans 'Sign up' %}</h1>
-{% wafer_form_helper 'wafer.registration.forms.RegistrationFormHelper' as form_helper %}
-{% crispy form form_helper %}
+{% crispy form %}
 {% endblock %}

--- a/wafer/registration/validators.py
+++ b/wafer/registration/validators.py
@@ -6,4 +6,4 @@ def validate_username(username):
     if username.startswith('.'):
         raise ValidationError('usernames cannot start with a "."')
     if username in ('index.html', 'page'):
-        raise ValidationError('Not an acceptable username')
+        raise ValidationError('This username is not available')

--- a/wafer/registration/validators.py
+++ b/wafer/registration/validators.py
@@ -8,3 +8,5 @@ def validate_username(username):
     if re.match(r'^\.+$', username):
         raise ValidationError(
             "usernames cannot consist of only .")
+    if username == 'index.html':
+        raise ValidationError('Not an acceptable username')

--- a/wafer/registration/validators.py
+++ b/wafer/registration/validators.py
@@ -1,0 +1,10 @@
+import re
+
+from django.core.exceptions import ValidationError
+
+
+def validate_username(username):
+    """. and .. lead to problematic URLs and static file names"""
+    if re.match(r'^\.+$', username):
+        raise ValidationError(
+            "usernames cannot consist of only .")

--- a/wafer/registration/validators.py
+++ b/wafer/registration/validators.py
@@ -1,12 +1,9 @@
-import re
-
 from django.core.exceptions import ValidationError
 
 
 def validate_username(username):
-    """. and .. lead to problematic URLs and static file names"""
-    if re.match(r'^\.+$', username):
-        raise ValidationError(
-            "usernames cannot consist of only .")
+    """Some usernames lead to problematic URLs and static file names"""
+    if username.startswith('.'):
+        raise ValidationError('usernames cannot start with a "."')
     if username in ('index.html', 'page'):
         raise ValidationError('Not an acceptable username')

--- a/wafer/registration/validators.py
+++ b/wafer/registration/validators.py
@@ -8,5 +8,5 @@ def validate_username(username):
     if re.match(r'^\.+$', username):
         raise ValidationError(
             "usernames cannot consist of only .")
-    if username == 'index.html':
+    if username in ('index.html', 'page'):
         raise ValidationError('Not an acceptable username')

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -199,8 +199,8 @@ LOGGING = {
 
 # Django registration:
 ACCOUNT_ACTIVATION_DAYS = 7
-
 AUTH_USER_MODEL = 'auth.User'
+REGISTRATION_FORM = 'wafer.registration.forms.WaferRegistrationForm'
 
 # Forms:
 CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/wafer/users/forms.py
+++ b/wafer/users/forms.py
@@ -7,6 +7,7 @@ from crispy_forms.bootstrap import PrependedText
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 
+from wafer.registration.validators import validate_username
 from wafer.users.models import UserProfile
 
 
@@ -21,6 +22,11 @@ class UserForm(forms.ModelForm):
         self.helper.add_input(Submit('submit', _('Save')))
         self.fields['first_name'].required = True
         self.fields['email'].required = True
+
+    def clean_username(self):
+        username = self.cleaned_data['username']
+        validate_username(username)
+        return username
 
     class Meta:
         # TODO: Password reset

--- a/wafer/users/views.py
+++ b/wafer/users/views.py
@@ -67,6 +67,9 @@ class ProfileView(Hide404Mixin, BuildableDetailView):
 
     def build_object(self, obj):
         """Override django-bakery to skip profiles that raise 403"""
+        if obj.username in ('.', '..'):
+            log.warning('Skipping build of user %s, bad username', obj.username)
+            return
         try:
             build_path = self.get_build_path(obj)
             self.request = self.create_request(build_path)


### PR DESCRIPTION
Ideally we'd probably customize the auth model, but we still haven't done that.

A user broke a debconf site static rendering, by having a username of `.` and no public talks. That resulted in all other user profiles created up to that point, being deleted. Good job, user :)

Let's protect ourselves from this sort of thing, in the future.