### PR TITLE
Talk state publication consistency

### DIFF
--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -66,6 +66,9 @@ class UserProfile(models.Model):
     def cancelled_talks(self):
         return self.user.talks.filter(status=CANCELLED)
 
+    def published_talks(self):
+        return self.user.talks.filter(status__in=(ACCEPTED, CANCELLED))
+
     def avatar_url(self, size=96, https=True, default='mm'):
         if not self.user.email:
             return None

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -130,23 +130,23 @@
         </div>
       {% endfor %}
     {% endif %}
-    {% if profile.provisional_talks.exists %}
-      <h2>{% trans 'Provisionally Accepted Talks:' %}</h2>
-      {% for talk in profile.provisional_talks %}
-        <div class="card">
-          <div class="card-body">
-            <h3 class="card-title">
-              <a href="{{ talk.get_absolute_url }}">
-                {{ talk.title }}
-              </a>
-            </h3>
-            <p>{{ talk.abstract.rendered|safe }}</p>
-          </div>
-        </div>
-      {% endfor %}
-    {% endif %}
     {# Submitted talk proposals are only visible to the owner #}
     {% if can_edit %}
+      {% if profile.provisional_talks.exists %}
+        <h2>{% trans 'Provisionally Accepted Talks:' %}</h2>
+        {% for talk in profile.provisional_talks %}
+          <div class="card">
+            <div class="card-body">
+              <h3 class="card-title">
+                <a href="{{ talk.get_absolute_url }}">
+                  {{ talk.title }}
+                </a>
+              </h3>
+              <p>{{ talk.abstract.rendered|safe }}</p>
+            </div>
+          </div>
+        {% endfor %}
+      {% endif %}
       {% if profile.pending_talks.exists %}
         <h2>{% trans 'Submitted or Under Consideration Talks:' %}</h2>
         {% for talk in profile.pending_talks %}

--- a/wafer/users/views.py
+++ b/wafer/users/views.py
@@ -12,7 +12,7 @@ from bakery.views import BuildableDetailView
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser
 
-from wafer.talks.models import ACCEPTED
+from wafer.talks.models import ACCEPTED, CANCELLED
 from wafer.users.forms import UserForm, UserProfileForm
 from wafer.users.serializers import UserSerializer
 from wafer.users.models import UserProfile
@@ -30,7 +30,7 @@ class UsersView(PaginatedBuildableListView):
     def get_queryset(self, *args, **kwargs):
         qs = super(UsersView, self).get_queryset(*args, **kwargs)
         if not settings.WAFER_PUBLIC_ATTENDEE_LIST:
-            qs = qs.filter(talks__status=ACCEPTED).distinct()
+            qs = qs.filter(talks__status__in=(ACCEPTED, CANCELLED)).distinct()
         qs = qs.order_by('first_name', 'last_name', 'username')
         return qs
 
@@ -84,7 +84,7 @@ class ProfileView(Hide404Mixin, BuildableDetailView):
         object_ = super(ProfileView, self).get_object(*args, **kwargs)
         if not settings.WAFER_PUBLIC_ATTENDEE_LIST:
             if (not self.can_edit(object_) and
-                    not object_.userprofile.accepted_talks().exists()):
+                    not object_.userprofile.published_talks().exists()):
                 raise PermissionDenied()
         return object_
 


### PR DESCRIPTION
We found some 404s when making the DebConf20 website static.

1. Cancelled talks linked to speakers whose profiles weren't visible.
2. Provisionally accepted talks were linked from profiles, but were 404 themselves.

Let's fix the inconsistencies.