### PR TITLE
Compile translations in CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -77,7 +77,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
-        pip install django~=${{ matrix.django-version }}
     - name: Install Django Release
       run: |
         pip install django~=${{ matrix.django-version }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -90,3 +90,22 @@ jobs:
       continue-on-error: ${{ matrix.django-version == '3.1.0' || matrix.django-version == 'main' }}
       run: |
         NOSE_WITH_COVERAGE=1 NOSE_COVER_PACKAGE=wafer python manage.py test
+
+  translations:
+    runs-on: ubuntu-latest
+    name: Compile Translations
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+    - name: Install gettext
+      run: |
+        sudo apt-get -y install gettext
+    - name: Compile Translations
+      run: |
+        cd wafer
+        python ../manage.py compilemessages


### PR DESCRIPTION
I had to quickly land 11359cacc4cee19aef9ff250f10f0f1026a83ed8 before releasing 0.10.0. We should catch these things earlier, with CI.

Weblate *does* know how to pick up on these issues and push back to translators, but it needs to be configured, and translators can override it.