### PR TITLE
Markdown: safe_mode is gone, bleach output instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from glob import glob
 import subprocess
-import sys
 
 from setuptools import find_packages, setup
 

--- a/setup.py
+++ b/setup.py
@@ -6,24 +6,24 @@ from setuptools import find_packages, setup
 
 REQUIRES = [
     'Django>=2.2,<3.1',
+    'diff-match-patch',
+    'django-bakery>=0.12.0',
     'django-crispy-forms',
+    'django-markitup>=4.0.0',
     'django-nose',
     'django-registration-redux',
+    'django-reversion',
+    'django-select2',
     'djangorestframework',
     'drf-extensions>=0.5.0',
+    'icalendar>=4.0',
     'jsonfield',
+    'markdown>=2.5',
     'pillow',
-    'diff-match-patch',
+    'py3dns',
     'pyLibravatar',
     'pytz',
     'requests',
-    'django-bakery>=0.12.0',
-    'django-select2',
-    'django-reversion',
-    'markdown>=2.5',
-    'icalendar>=4.0',
-    'py3dns',
-    'django-markitup>=4.0.0',
 ]
 
 SOURCES = []

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from setuptools import find_packages, setup
 
 REQUIRES = [
     'Django>=2.2,<3.1',
+    'bleach',
+    'bleach-allowlist',
     'diff-match-patch',
     'django-bakery>=0.12.0',
     'django-crispy-forms',

--- a/wafer/markdown.py
+++ b/wafer/markdown.py
@@ -1,0 +1,10 @@
+import bleach
+from bleach_allowlist import markdown_tags, markdown_attrs
+from markdown import markdown
+
+
+def bleached_markdown(text, **kwargs):
+    """Try to avoid XSS by bleaching markdown output"""
+    markdown_rendered = markdown(text, **kwargs)
+    bleached = bleach.clean(markdown_rendered, markdown_tags, markdown_attrs)
+    return bleached

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -298,7 +298,7 @@ WAFER_PUBLIC_ATTENDEE_LIST = True
 # django-bakery -- disk-based renderer
 BUILD_DIR = os.path.join(project_root, 'static_mirror')
 
-MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
+MARKITUP_FILTER = ('wafer.markdown.bleached_markdown', {})
 JQUERY_URL = None
 SELECT2_USE_BUNDLED_JQUERY = False
 

--- a/wafer/sponsors/templates/wafer.sponsors/packages.html
+++ b/wafer/sponsors/templates/wafer.sponsors/packages.html
@@ -20,7 +20,7 @@
             {% endif %}
             <p>{% trans 'Packages claimed:' %} {{ package.number_claimed }}</p>
             <p>{{ package.short_description }}</p>
-            {{ package.description.rendered|safe }}
+            {{ package.description }}
           </div>
         </div>
       </section>

--- a/wafer/sponsors/templates/wafer.sponsors/sponsor.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsor.html
@@ -19,7 +19,7 @@
         </a>
       </div>
     {% endif %}
-    {{ object.description.rendered|safe }}
+    {{ object.description }}
   </div>
 </section>
 {% endblock %}

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors.html
@@ -30,7 +30,7 @@
                 </a>
               </div>
             {% endif %}
-            {{ sponsor.description.rendered|safe }}
+            {{ sponsor.description }}
           </div>
         </div>
         <hr>

--- a/wafer/talks/templates/wafer.talks/talk.html
+++ b/wafer/talks/templates/wafer.talks/talk.html
@@ -129,7 +129,7 @@
     </div>
   {% endif %}
   <div id="abstract">
-    {{ object.abstract.rendered|safe }}
+    {{ object.abstract }}
   </div>
   {% if perms.talks.view_all_talks or user.is_superuser %}
     {% if talk.notes %}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -110,7 +110,7 @@
                 {{ talk.title }}
               </a>
             </h3>
-            <p>{{ talk.abstract.rendered|safe }}</p>
+            <p>{{ talk.abstract }}</p>
           </div>
         </div>
       {% endfor %}
@@ -125,7 +125,7 @@
                 {{ talk.title }}
               </a>
             </h3>
-            <p>{{ talk.abstract.rendered|safe }}</p>
+            <p>{{ talk.abstract }}</p>
           </div>
         </div>
       {% endfor %}
@@ -142,7 +142,7 @@
                   {{ talk.title }}
                 </a>
               </h3>
-              <p>{{ talk.abstract.rendered|safe }}</p>
+              <p>{{ talk.abstract }}</p>
             </div>
           </div>
         {% endfor %}
@@ -167,7 +167,7 @@
                   {{ talk.title }}
                 </a>
               </h3>
-              <p>{{ talk.abstract.rendered|safe }}</p>
+              <p>{{ talk.abstract }}</p>
             </div>
           </div>
         {% endfor %}


### PR DESCRIPTION
Run the HTML from markdown through bleach, to protect against XSS.