### PR TITLE
A markdown extension that allows referencing staticfiles

### DIFF
--- a/wafer/contrib/mdx_static.py
+++ b/wafer/contrib/mdx_static.py
@@ -1,0 +1,28 @@
+import re
+
+from django.contrib.staticfiles.templatetags.staticfiles import static
+
+from markdown.extensions import Extension
+from markdown.postprocessors import Postprocessor
+
+assetRE = re.compile(r'{% static [\'"](.*?)[\'"] %}')
+
+
+class DjangoStaticAssetsProcessor(Postprocessor):
+    def replacement(self, match):
+        path = match.group(1)
+        url = static(path)
+        return url
+
+    def run(self, text):
+        return assetRE.sub(self.replacement, text)
+
+
+class StaticExtension(Extension):
+    def extendMarkdown(self, md, md_globals):
+        md.postprocessors.add('django_static_assets',
+                              DjangoStaticAssetsProcessor(md), '_end')
+
+
+def makeExtension(**kwargs):
+    return StaticExtension(**kwargs)


### PR DESCRIPTION
It can be useful to reference static assets managed by `django.contrib.staticfiles` in Markdown text.  e.g. to link to a large video that we want a high cache TTL on.

DebConf has been carrying this since 2019 (although I don't think we've used it since), but it really seems more generically useful than our needs.

Not sure if wafer really wants to grow a contrib, or not, though.