### PR TITLE
Talk.review_score: do not exclude zeros

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -309,7 +309,7 @@ class Talk(models.Model):
     @property
     def review_score(self):
         # Overridden in admin, to allow sorting
-        reviews = [review.avg_score for review in self.reviews.all() if review.avg_score]
+        reviews = [review.avg_score for review in self.reviews.all() if review.avg_score is not None]
         if not reviews:
             return None
         return sum(reviews) / len(reviews)


### PR DESCRIPTION
This make the review score calculation in Talk.review_score at least
provide the same value as the one in the admin (which is calculated via
an SQL aggregate).