### PR TITLE
Emit frab compatible XML

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -22,6 +22,9 @@ Wafer's settings
     The name of the Django cache backend that wafer can use.
     Defaults to ``'wafer_cache'``.
 
+``WAFER_CONFERENCE_ACRONYM``
+    The abbreviated name of the conference.
+
 ``WAFER_DEFAULT_GROUPS``
     A list of groups that any new user is automatically added to.
     This can be used to tweak the default permissions available

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 PyYAML
+lxml
 mock
 pep8
 pyflakes

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.signals import post_save, post_delete
@@ -342,6 +344,11 @@ class ScheduleItem(models.Model):
         """Return the duration in total number of minutes."""
         duration = self.get_duration()
         return int(duration['hours'] * 60 + duration['minutes'])
+
+    @property
+    def guid(self):
+        """Return a GUID for the ScheduleItem (for frab xml)"""
+        return UUID(int=self.pk)
 
 
 def invalidate_check_schedule(*args, **kw):

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -299,6 +299,13 @@ class ScheduleItem(models.Model):
             return self.page.get_absolute_url()
         return None
 
+    def get_slug(self):
+        if self.talk:
+            return self.talk.slug
+        elif self.page:
+            return self.page.slug
+        return None
+
     def get_details(self):
         return self.get_desc()
 

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.signals import post_save, post_delete
 from django.urls import reverse
+from django.utils.crypto import salted_hmac
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import localtime
 
@@ -355,7 +356,8 @@ class ScheduleItem(models.Model):
     @property
     def guid(self):
         """Return a GUID for the ScheduleItem (for frab xml)"""
-        return UUID(int=self.pk)
+        hmac = salted_hmac('wafer-event-uuid', str(self.pk))
+        return UUID(bytes=hmac.digest()[:16])
 
 
 def invalidate_check_schedule(*args, **kw):

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -120,13 +120,7 @@
                         <license>{{ WAFER_VIDEO_LICENSE }}</license>
                       </recording>
                     {% endif %}
-                    <conf_url>{{ items.item.get_url }}</conf_url>
-                    {# It's useful to have the full url available in the xml file. The pentabarf.xml format isn't that well #}
-                    {# standardised, so we add our own full_conf_url tag to accomodate this requirement #}
-
-                    {# forcing https here is a bit horrible - make this configurable somewhere? #}
-                    <full_conf_url>https://{{ WAFER_CONFERENCE_DOMAIN }}{{ items.item.get_url }}</full_conf_url>
-
+                    <url>https://{{ WAFER_CONFERENCE_DOMAIN }}{{ items.item.get_url }}</url>
                   </event>
                 {% endif %}
               {% endfor %}

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -14,8 +14,9 @@
         {% endwith %}
         <days>{{ schedule_pages|length }}</days>
       {% endif %}
-    <day_change>00:00</day_change>
     <timeslot_duration>00:15</timeslot_duration>
+    <base_url>https://{{ WAFER_CONFERENCE_DOMAIN }}</base_url>
+    <time_zone_name>{{ TIME_ZONE }}</time_zone_name>
   </conference>
   {% for page in schedule_pages %}
     <day date="{{ page.block.start_time|date:'Y-m-d' }}" index="{{ forloop.counter }}">

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 {% load i18n %}
 <schedule>
+  <generator name="wafer" version="{{ wafer_version }}" />
   <conference>
     <title>{{ WAFER_CONFERENCE_NAME }}</title>
       {% if schedule_pages %}

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -37,21 +37,16 @@
                     {% endwith %}
                     <room>{{ venue.name }}</room>
                     <track>{{ items.item.talk.track.name|default:"No Track" }}</track>
-                    {# It's not clear what the difference between abstract and description is meant to be #}
-                    {# Both confclerk and Giggity just lump them together into the same thing anyway, and #}
-                    {# summit only outputs stuff in description, so we keep abstract blank and follow #}
-                    {# summit's pattern and only include stuff in the description #}
+                    {# Abstract is defined to be a 1-paragraph summary, displayed before description. #}
+                    {# That doesn't match our data model, so we leave it blank. #}
                     <abstract/>
                     <subtitle/>
                     <slug>{{ WAFER_CONFERENCE_ACRONYM|lower }}-{{ items.item.pk }}-{{ items.item.get_slug }}</slug>
                     {% if items.item.talk %}
                       {% with talk=items.item.talk %}
                         <title>{{ items.item.get_title }}</title>
-                        {# I'm not sure if the raw markdown is the best thing here, but it seems to match what summit does, #}
-                        {# so hopefully the tools can handle the odd corner cases correctly. Giggity at least does some #}
-                        {# santization here. #}
-                        {# We do allow people to request html if they want it, which may also be a bad idea, but is useful for #}
-                        {# the video team #}
+                        {# description is allowed to be HTML or Markdown #}
+                        {# We let the requester select their desired format #}
                         {% if talk.abstract and render_description %}
                           <description>{{ talk.abstract.rendered }}</description>
                         {% elif talk.abstract %}

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -17,6 +17,7 @@
     <timeslot_duration>00:15</timeslot_duration>
     <base_url>https://{{ WAFER_CONFERENCE_DOMAIN }}</base_url>
     <time_zone_name>{{ TIME_ZONE }}</time_zone_name>
+    <acronym>{{ WAFER_CONFERENCE_ACRONYM }}</acronym>
   </conference>
   {% for page in schedule_pages %}
     <day date="{{ page.block.start_time|date:'Y-m-d' }}" index="{{ forloop.counter }}">

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -43,6 +43,7 @@
                     {# summit's pattern and only include stuff in the description #}
                     <abstract/>
                     <subtitle/>
+                    <slug>{{ WAFER_CONFERENCE_ACRONYM|lower }}-{{ items.item.pk }}-{{ items.item.get_slug }}</slug>
                     {% if items.item.talk %}
                       {% with talk=items.item.talk %}
                         <title>{{ items.item.get_title }}</title>

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -2,6 +2,7 @@
 {% load i18n %}
 <schedule>
   <generator name="wafer" version="{{ wafer_version }}" />
+  <version>{# FIXME: We have no schedule versions #}</version>
   <conference>
     <title>{{ WAFER_CONFERENCE_NAME }}</title>
       {% if schedule_pages %}

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -76,10 +76,14 @@
                           {% endfor %}
                         </persons>
                         <abstract/>
-                        <released>{{ talk.video }}</released>
-                        {% if talk.video %}
-                          <license>{{ WAFER_VIDEO_LICENSE }}</license>
-                        {% endif %}
+                        <recording>
+                          {% if talk.video %}
+                            <optout>false</optout>
+                            <license>{{ WAFER_VIDEO_LICENSE }}</license>
+                          {% else %}
+                            <optout>true</optout>
+                          {% endif %}
+                        </recording>
                       {% endwith %}
                     {% else %}
                       <title>{{ items.item.get_details|escape }}</title>
@@ -111,8 +115,10 @@
                       {% else %}
                         <description/>
                       {% endif %}
-                      <released>True</released>
-                      <license>{{ WAFER_VIDEO_LICENSE }}</license>
+                      <recording>
+                        <optout>false</optout>
+                        <license>{{ WAFER_VIDEO_LICENSE }}</license>
+                      </recording>
                     {% endif %}
                     <conf_url>{{ items.item.get_url }}</conf_url>
                     {# It's useful to have the full url available in the xml file. The pentabarf.xml format isn't that well #}

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -42,6 +42,7 @@
                     {# summit only outputs stuff in description, so we keep abstract blank and follow #}
                     {# summit's pattern and only include stuff in the description #}
                     <abstract/>
+                    <subtitle/>
                     {% if items.item.talk %}
                       {% with talk=items.item.talk %}
                         <title>{{ items.item.get_title }}</title>

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -29,7 +29,7 @@
               {% for row_venue, items in row.items.items %}
                 {% if row_venue == venue and items.item %}
                   {# The event id is the ScheduleItem pk, which should be unique enough #}
-                  <event id="{{ items.item.pk }}">
+                  <event id="{{ items.item.pk }}" guid="{{ items.item.guid }}">
                     <date>{{ row.start_time.isoformat }}</date>
                     <start>{{ row.start_time|time:"H:i" }}</start>
                     {% with dur=items.item.get_duration %}

--- a/wafer/schedule/tests/frab.xml.xsd
+++ b/wafer/schedule/tests/frab.xml.xsd
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<!--
+The Frab XSD isn't versioned yet (and it seems unlikely to happen, from
+https://github.com/frab/schedule.xml/issues/4)
+So, grabbed from voc git:
+https://github.com/voc/schedule/commit/1e22ff63d1b03e959fdf0b9771beeee7bae1b75e
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="schedule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" name="generator">
+          <xs:complexType>
+            <xs:sequence />
+            <xs:attribute type="xs:string" name="name"/>
+            <xs:attribute type="xs:string" name="version"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element type="xs:string" name="version"/>
+        <xs:element name="conference">
+          <xs:complexType>
+            <xs:all>
+              <xs:element type="xs:string"  name="title"/>
+              <xs:element type="acronym"  name="acronym"/>
+
+              <xs:element type="xs:date"    name="start" minOccurs="0"/>
+              <xs:element type="xs:date"    name="end" minOccurs="0"/>
+              <xs:element type="xs:integer" name="days" minOccurs="0"/>
+              <xs:element type="duration"   name="timeslot_duration" minOccurs="0"/>
+              <xs:element type="httpURI"    name="base_url" minOccurs="0"/>
+              <xs:element type="xs:string"  name="time_zone_name" minOccurs="0" maxOccurs="1"/>
+            </xs:all>
+          </xs:complexType>
+        </xs:element>
+        <xs:element type="day" name="day" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+
+    <xs:unique name="guid_unique">
+      <xs:selector xpath="day/room/event" />
+      <xs:field xpath="@guid" />
+    </xs:unique>
+
+    <xs:unique name="id_unique">
+      <xs:selector xpath="day/room/event" />
+      <xs:field xpath="@id" />
+    </xs:unique>
+
+    <xs:unique name="slug_unique">
+      <xs:selector xpath="day/room/event/slug" />
+      <xs:field xpath="." />
+    </xs:unique>
+
+    <xs:unique name="day_index_unique">
+      <xs:selector xpath="day" />
+      <xs:field xpath="@index" />
+    </xs:unique>
+  </xs:element>
+
+  <xs:complexType name="day">
+    <xs:sequence>
+      <xs:element type="room" name="room" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute type="xs:date" name="date"/>
+    <xs:attribute type="dateTimeTZ" name="start"/>
+    <xs:attribute type="dateTimeTZ" name="end"/>
+    <xs:attribute type="xs:positiveInteger" name="index"/>
+  </xs:complexType>
+
+  <xs:complexType name="room">
+    <xs:sequence>
+      <xs:element type="event" name="event" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="name" use="required"/>
+    <xs:attribute name="guid" type="uuid"/>
+  </xs:complexType>
+
+  <xs:complexType name="event">
+    <xs:all>
+      <xs:element type="xs:string" name="room"/>
+      <xs:element type="xs:string" name="title"/>
+      <xs:element type="xs:string" name="subtitle"/>
+      <xs:element type="xs:string" name="type"/>
+      <xs:element type="dateTimeTZ" name="date"/>
+      <xs:element type="start" name="start"/>
+      <xs:element type="duration" name="duration"/>
+      <xs:element type="xs:string" name="abstract"/>
+      <xs:element type="slug" name="slug"/>
+      <xs:element type="xs:string" name="track"/>
+
+      <xs:element type="xs:string" name="logo" minOccurs="0"/>
+      <xs:element type="persons" name="persons" minOccurs="0"/>
+      <xs:element type="xs:string" name="language" minOccurs="0"/>
+      <xs:element type="xs:string" name="description" minOccurs="0"/>
+      <xs:element type="recording" name="recording" minOccurs="0"/>
+      <xs:element type="links" name="links" minOccurs="0"/>
+      <xs:element type="attachments" name="attachments" minOccurs="0"/>
+      <xs:element type="httpURI" name="video_download_url" minOccurs="0"/>
+      <xs:element type="httpURI" name="url" minOccurs="0"/>
+    </xs:all>
+    <xs:attribute name="id" type="xs:positiveInteger" use="required"/>
+    <xs:attribute name="guid" type="uuid" use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="dateTimeTZ">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value=".+(Z|\+[0-9]{1,2}:[0-9]{2}|-[0-9]{1,2}:[0-9]{2})"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="duration">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([0-9]{1,2}:[0-9]{2})|([0-9]{1,2}:[0-9]{2}:[0-9]{1,2})"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="start">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([0-2][0-9]:[0-5][0-9])|([0-2][0-9]:[0-5][0-9]:[0-5][0-9])"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="uuid">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="acronym">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9_-]{4,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="slug">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9]{4,}-[0-9]{1,6}-[a-z0-9\-_]{4,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="httpURI">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="https?://.*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="recording">
+    <xs:all>
+      <xs:element type="xs:string"  name="license"/>
+      <xs:element type="xs:boolean" name="optout"/>
+      <xs:element type="httpURI" name="url" minOccurs="0"/>
+      <xs:element type="httpURI" name="link" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="persons">
+    <xs:sequence>
+      <xs:element name="person" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute type="xs:positiveInteger" name="id"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="links">
+    <xs:sequence>
+      <xs:element name="link" maxOccurs="unbounded" minOccurs="0">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute type="xs:string" name="href"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="attachments">
+    <xs:sequence>
+      <xs:element name="attachment" maxOccurs="unbounded" minOccurs="0">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute type="xs:string" name="href"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -1500,19 +1500,20 @@ class NonHTMLViewTests(TestCase):
         parsed = ElementTree.XML(response.content)
         self.assertEqual(parsed.tag, 'schedule')
         self.assertEqual(parsed[0].tag, 'generator')
-        self.assertEqual(parsed[1].tag, 'conference')
-        self.assertEqual(parsed[2].tag, 'day')
+        self.assertEqual(parsed[1].tag, 'version')
+        self.assertEqual(parsed[2].tag, 'conference')
+        self.assertEqual(parsed[3].tag, 'day')
 
         # Various tools expect 'start' and 'end' values, so
         # check we have those
-        conf = parsed[1]
+        conf = parsed[2]
         self.assertEqual('title', conf[0].tag)
         self.assertEqual('start', conf[1].tag)
         self.assertEqual('end', conf[2].tag)
         self.assertEqual('2013-09-22', conf[1].text)
         self.assertEqual('2013-09-23', conf[2].text)
 
-        day = parsed[2]
+        day = parsed[3]
         self.assertIn(('date', '2013-09-22'), day.items())
         self.assertEqual(day[0].tag, 'room')
         self.assertIn(('name', 'Venue 1'), day[0].items())

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -1499,19 +1499,20 @@ class NonHTMLViewTests(TestCase):
         response = c.get('/schedule/pentabarf.xml')
         parsed = ElementTree.XML(response.content)
         self.assertEqual(parsed.tag, 'schedule')
-        self.assertEqual(parsed[0].tag, 'conference')
-        self.assertEqual(parsed[1].tag, 'day')
+        self.assertEqual(parsed[0].tag, 'generator')
+        self.assertEqual(parsed[1].tag, 'conference')
+        self.assertEqual(parsed[2].tag, 'day')
 
         # Various tools expect 'start' and 'end' values, so
         # check we have those
-        conf = parsed[0]
+        conf = parsed[1]
         self.assertEqual('title', conf[0].tag)
         self.assertEqual('start', conf[1].tag)
         self.assertEqual('end', conf[2].tag)
         self.assertEqual('2013-09-22', conf[1].text)
         self.assertEqual('2013-09-23', conf[2].text)
 
-        day = parsed[1]
+        day = parsed[2]
         self.assertIn(('date', '2013-09-22'), day.items())
         self.assertEqual(day[0].tag, 'room')
         self.assertIn(('name', 'Venue 1'), day[0].items())

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from bakery.views import BuildableDetailView, BuildableTemplateView, BuildableMixin
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser
+from wafer import __version__
 from wafer.pages.models import Page
 from wafer.schedule.models import Venue, Slot, ScheduleBlock, ScheduleItem
 from wafer.schedule.admin import check_schedule, validate_schedule
@@ -191,6 +192,7 @@ class ScheduleXmlView(ScheduleView):
     def get_context_data(self, **kwargs):
         """Allow adding a 'render_description' parameter"""
         context = super().get_context_data(**kwargs)
+        context['wafer_version'] = __version__
         if self.request.GET.get('render_description', None) == '1':
             context['render_description'] = True
         else:

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -193,6 +193,7 @@ class ScheduleXmlView(ScheduleView):
         """Allow adding a 'render_description' parameter"""
         context = super().get_context_data(**kwargs)
         context['wafer_version'] = __version__
+        context['TIME_ZONE'] = settings.TIME_ZONE
         if self.request.GET.get('render_description', None) == '1':
             context['render_description'] = True
         else:

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -194,6 +194,7 @@ class ScheduleXmlView(ScheduleView):
         context = super().get_context_data(**kwargs)
         context['wafer_version'] = __version__
         context['TIME_ZONE'] = settings.TIME_ZONE
+        context['WAFER_CONFERENCE_ACRONYM'] = settings.WAFER_CONFERENCE_ACRONYM
         if self.request.GET.get('render_description', None) == '1':
             context['render_description'] = True
         else:

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -242,6 +242,9 @@ WAFER_DYNAMIC_MENUS = (
     'wafer.sponsors.models.sponsor_menu',
 )
 
+# Short name for the conference
+WAFER_CONFERENCE_ACRONYM = 'waferconf'
+
 # Enabled SSO mechanims:
 WAFER_SSO = (
     # 'github',


### PR DESCRIPTION
While `pentabarf.xml` is a largely undocumented format, frab has a defined schema: https://c3voc.de/wiki/schedule

This is a fairly minimal change to bring our pentabarf XML format into line with frab's schema.
We could carry both side-by-side, but they're close enough that it probably makes sense to stick with a well defined schema.
Tools will have to be changed to support this, but there aren't that many of them, it should be manageable.

The reason for this was to add support for https://eventfahrplan.eu/ as a client app.