### PR TITLE
schedule editor: display talk notes as title

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/edit_schedule.html
+++ b/wafer/schedule/templates/wafer.schedule/edit_schedule.html
@@ -119,7 +119,7 @@
                     class="badge badge-success draggable"
                     id="talk{{ talk.talk_id }}"
                     data-toggle="tooltip" data-placement="left"
-                    title="{{ talk.title }}"
+                    title="{{ talk.notes|default:"(no notes)" }}"
                     {% if talk not in talks_unassigned %}
                       hidden
                     {% endif %}


### PR DESCRIPTION
Displaying the talk title again in the title is pointless since the
title is already the main element displayed. Showing the notes makes it
easier for the people doing the scheduling to see e.g. notes about
scheduling restrictions etc.