### PR TITLE
Tests: Use common test and user creation fixture functions

### DIFF
--- a/wafer/pages/tests/test_pages.py
+++ b/wafer/pages/tests/test_pages.py
@@ -1,54 +1,26 @@
 # Simple test of the edit logic around pages
 
 from django.test import Client, TestCase, override_settings
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches
 
 from wafer.pages.models import Page
+from wafer.tests.utils import create_user
 
 
 class PageEditTests(TestCase):
 
-    def _make_users(self):
-        # utiltiy function for tests
-        UserModel = get_user_model()
-
-        # Make user without edit permissions
-        try:
-            no_edit_user = UserModel.objects.filter(username='no_edit').get()
-        except UserModel.DoesNotExist:
-            no_edit_user = UserModel.objects.create_user('no_edit',
-                                                         'test@test',
-                                                         'aaaa')
-            no_edit_user.save()
-
-        # Make user with edit permissions
-        try:
-            edit_user = UserModel.objects.filter(username='can_edit').get()
-        except UserModel.DoesNotExist:
-            edit_user = UserModel.objects.create_user('can_edit',
-                                                      'test@test',
-                                                      'aaaa')
-            # Is there a better way to do this?
-            page_content_type = ContentType.objects.get_for_model(Page)
-            change_page = Permission.objects.get(
-                content_type=page_content_type, codename='change_page')
-
-            edit_user.user_permissions.add(change_page)
-            edit_user.save()
-
-        return no_edit_user, edit_user
+    def setUp(self):
+        self.no_edit_user = create_user('no_edit')
+        self.edit_user = create_user('can_edit', perms=('change_page',))
 
     def test_simple_page(self):
         # Test editing a page we create
-        no_edit_user, edit_user = self._make_users()
         page = Page.objects.create(name="test edit page", slug="test_edit")
         page.save()
         c = Client()
         # Test without edit permission
-        c.login(username=no_edit_user.username, password='aaaa')
+        c.login(username=self.no_edit_user.username,
+                password='no_edit_password')
         response = c.get('/test_edit/')
         templates = [x.name for x in response.templates]
         self.assertTrue('wafer.pages/page.html' in templates)
@@ -56,7 +28,7 @@ class PageEditTests(TestCase):
         self.assertEqual(response.status_code, 403)
         c.logout()
         # Test with edit permission
-        c.login(username=edit_user.username, password='aaaa')
+        c.login(username=self.edit_user.username, password='can_edit_password')
         response = c.get('/test_edit/')
         templates = [x.name for x in response.templates]
         self.assertTrue('wafer.pages/page.html' in templates)
@@ -67,12 +39,12 @@ class PageEditTests(TestCase):
 
     def test_root_page(self):
         # Test editing /
-        no_edit_user, edit_user = self._make_users()
         page = Page.objects.create(name="index", slug="index")
         page.save()
         c = Client()
         # Test without edit permission
-        c.login(username=no_edit_user.username, password='aaaa')
+        c.login(username=self.no_edit_user.username,
+                password='no_edit_password')
         response = c.get('/index', follow=True)
         templates = [x.name for x in response.templates]
         self.assertTrue('wafer.pages/page.html' in templates)
@@ -81,7 +53,7 @@ class PageEditTests(TestCase):
         self.assertEqual(response.status_code, 403)
         c.logout()
         # Test with edit permission
-        c.login(username=edit_user.username, password='aaaa')
+        c.login(username=self.edit_user.username, password='can_edit_password')
         response = c.get('/index', follow=True)
         templates = [x.name for x in response.templates]
         self.assertTrue('wafer.pages/page.html' in templates)

--- a/wafer/schedule/tests/test_admin.py
+++ b/wafer/schedule/tests/test_admin.py
@@ -1,6 +1,5 @@
 import datetime as D
 
-from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.http import HttpRequest
 from django.utils import timezone
@@ -14,6 +13,7 @@ from wafer.schedule.admin import (
 from wafer.schedule.models import ScheduleBlock, Venue, Slot, ScheduleItem
 from wafer.talks.models import (Talk, ACCEPTED, REJECTED, CANCELLED,
                                 SUBMITTED, UNDER_CONSIDERATION)
+from wafer.tests.utils import create_user
 
 
 class DummyForm(object):
@@ -486,8 +486,7 @@ class ValidationTests(TestCase):
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
 
-        user = get_user_model().objects.create_user('john', 'best@wafer.test',
-                                                    'johnpassword')
+        user = create_user('john')
         talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                    corresponding_author_id=user.id)
         page = Page.objects.create(name="test page", slug="test")
@@ -564,8 +563,7 @@ class ValidationTests(TestCase):
         slot2 = Slot.objects.create(start_time=start2, end_time=start3)
         slot3 = Slot.objects.create(start_time=start3, end_time=end)
 
-        user = get_user_model().objects.create_user('john', 'best@wafer.test',
-                                                    'johnpassword')
+        user = create_user('john')
         talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                    corresponding_author_id=user.id)
         page = Page.objects.create(name="test page", slug="test")
@@ -617,8 +615,7 @@ class ValidationTests(TestCase):
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
 
-        user = get_user_model().objects.create_user('john', 'best@wafer.test',
-                                                    'johnpassword')
+        user = create_user('john')
         talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                    corresponding_author_id=user.id)
         page1 = Page.objects.create(name="test page", slug="test")

--- a/wafer/schedule/tests/test_admin.py
+++ b/wafer/schedule/tests/test_admin.py
@@ -11,9 +11,9 @@ from wafer.schedule.admin import (
     find_invalid_venues, find_non_contiguous, prefetch_schedule_items,
     validate_items, validate_schedule)
 from wafer.schedule.models import ScheduleBlock, Venue, Slot, ScheduleItem
-from wafer.talks.models import (Talk, ACCEPTED, REJECTED, CANCELLED,
-                                SUBMITTED, UNDER_CONSIDERATION)
-from wafer.tests.utils import create_user
+from wafer.talks.models import (ACCEPTED, REJECTED, CANCELLED, SUBMITTED,
+                                UNDER_CONSIDERATION)
+from wafer.talks.tests.fixtures import create_talk
 
 
 class DummyForm(object):
@@ -486,9 +486,7 @@ class ValidationTests(TestCase):
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
 
-        user = create_user('john')
-        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                   corresponding_author_id=user.id)
+        talk = create_talk('Test talk', status=ACCEPTED, username='john')
         page = Page.objects.create(name="test page", slug="test")
 
         item1 = ScheduleItem.objects.create(venue=venue1,
@@ -563,9 +561,7 @@ class ValidationTests(TestCase):
         slot2 = Slot.objects.create(start_time=start2, end_time=start3)
         slot3 = Slot.objects.create(start_time=start3, end_time=end)
 
-        user = create_user('john')
-        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                   corresponding_author_id=user.id)
+        talk = create_talk('Test Talk', status=ACCEPTED, username='john')
         page = Page.objects.create(name="test page", slug="test")
 
         item1 = ScheduleItem.objects.create(venue=venue1,
@@ -615,9 +611,7 @@ class ValidationTests(TestCase):
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
 
-        user = create_user('john')
-        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                   corresponding_author_id=user.id)
+        talk = create_talk('Test talk', status=ACCEPTED, username='john')
         page1 = Page.objects.create(name="test page", slug="test")
         page2 = Page.objects.create(name="test page 2", slug="test2")
 

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -5,15 +5,15 @@ from io import BytesIO
 from xml.etree import ElementTree
 
 from django.test import Client, TestCase
-from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 import icalendar
 import lxml.etree
 
-from wafer.talks.models import Talk, ACCEPTED
 from wafer.pages.models import Page
 from wafer.schedule.models import ScheduleBlock, Venue, Slot, ScheduleItem
+from wafer.talks.models import Talk, ACCEPTED
+from wafer.tests.utils import create_user
 from wafer.utils import QueryTracker
 
 
@@ -63,13 +63,8 @@ def make_slot():
 def create_client(username=None, superuser=False):
     client = Client()
     if username:
-        email = '%s@example.com' % (username,)
+        create_user(username, superuser=superuser)
         password = '%s_password' % (username,)
-        if superuser:
-            create = get_user_model().objects.create_superuser
-        else:
-            create = get_user_model().objects.create_user
-        create(username, email, password)
         client.login(username=username, password=password)
     return client
 
@@ -1427,8 +1422,7 @@ class CurrentViewTests(TestCase):
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
 
-        user = get_user_model().objects.create_user('john', 'best@wafer.test',
-                                                    'johnpassword')
+        user = create_user('john')
         talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                    corresponding_author_id=user.id)
 
@@ -1492,8 +1486,7 @@ class NonHTMLViewTests(TestCase):
         for index, item in enumerate(items):
             item.slots.add(slots[index // 2])
 
-        user = get_user_model().objects.create_user('john', 'best@wafer.test',
-                                                    'johnpassword')
+        user = create_user('john')
         talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                    corresponding_author_id=user.id)
         talk_item = ScheduleItem.objects.create(venue=venue1, talk_id=talk.pk)
@@ -1602,8 +1595,7 @@ class JsonViewTests(TestCase):
         for index, item in enumerate(items):
             item.slots.add(slots[(index + 1) // 2])
 
-        user = get_user_model().objects.create_user('jimbob', 'best@wafer.test',
-                                                    'johnpassword')
+        user = create_user('jimbob')
 
         talk1 = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                     corresponding_author_id=user.id)

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -12,7 +12,8 @@ import lxml.etree
 
 from wafer.pages.models import Page
 from wafer.schedule.models import ScheduleBlock, Venue, Slot, ScheduleItem
-from wafer.talks.models import Talk, ACCEPTED
+from wafer.talks.models import ACCEPTED
+from wafer.talks.tests.fixtures import create_talk
 from wafer.tests.utils import create_user
 from wafer.utils import QueryTracker
 
@@ -1422,9 +1423,7 @@ class CurrentViewTests(TestCase):
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
 
-        user = create_user('john')
-        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                   corresponding_author_id=user.id)
+        talk = create_talk('Test talk', status=ACCEPTED, username='john')
 
         item1 = ScheduleItem.objects.create(venue=venue1,
                                             talk_id=talk.pk)
@@ -1486,9 +1485,7 @@ class NonHTMLViewTests(TestCase):
         for index, item in enumerate(items):
             item.slots.add(slots[index // 2])
 
-        user = create_user('john')
-        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                   corresponding_author_id=user.id)
+        talk = create_talk('Test talk', status=ACCEPTED, username='john')
         talk_item = ScheduleItem.objects.create(venue=venue1, talk_id=talk.pk)
         talk_item.slots.add(slots[4])
 
@@ -1595,15 +1592,8 @@ class JsonViewTests(TestCase):
         for index, item in enumerate(items):
             item.slots.add(slots[(index + 1) // 2])
 
-        user = create_user('jimbob')
-
-        talk1 = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                    corresponding_author_id=user.id)
-        talk1.authors.add(user)
-
-        talk2 = Talk.objects.create(title="Test 2 talk", status=ACCEPTED,
-                                    corresponding_author_id=user.id)
-        talk2.authors.add(user)
+        talk1 = create_talk('Test talk', status=ACCEPTED, username='jimbob')
+        talk2 = create_talk('Test 2 talk', status=ACCEPTED, username='jimbob2')
 
         item1 = ScheduleItem.objects.create(venue=venue1,
                                             talk_id=talk1.pk)

--- a/wafer/talks/tests/fixtures.py
+++ b/wafer/talks/tests/fixtures.py
@@ -7,8 +7,9 @@ def create_talk_type(name):
     return TalkType.objects.create(name=name)
 
 
-def create_talk(title, status, username, talk_type=None):
-    user = create_user(username)
+def create_talk(title, status, username=None, user=None, talk_type=None):
+    if username:
+        user = create_user(username)
     talk = Talk.objects.create(
         title=title, status=status, corresponding_author_id=user.id)
     talk.authors.add(user)

--- a/wafer/talks/tests/fixtures.py
+++ b/wafer/talks/tests/fixtures.py
@@ -8,6 +8,8 @@ def create_talk_type(name):
 
 
 def create_talk(title, status, username=None, user=None, talk_type=None):
+    if sum((user is None, username is None)) != 1:
+        raise ValueError('One of user OR username must be specified')
     if username:
         user = create_user(username)
     talk = Talk.objects.create(

--- a/wafer/talks/tests/fixtures.py
+++ b/wafer/talks/tests/fixtures.py
@@ -1,0 +1,21 @@
+from wafer.talks.models import Talk, TalkType
+from wafer.tests.utils import create_user
+
+
+def create_talk_type(name):
+    """Create a talk type"""
+    return TalkType.objects.create(name=name)
+
+
+def create_talk(title, status, username, talk_type=None):
+    user = create_user(username)
+    talk = Talk.objects.create(
+        title=title, status=status, corresponding_author_id=user.id)
+    talk.authors.add(user)
+    talk.notes = "Some notes for talk %s" % title
+    talk.private_notes = "Some private notes for talk %s" % title
+    talk.save()
+    if talk_type:
+        talk.talk_type = talk_type
+        talk.save()
+    return talk

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -506,6 +506,7 @@ class SpeakerTests(TestCase):
             '</div>',
         ]), html=True)
 
+    @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_exluding_types(self):
         """Test that the show_speakers flag excludes the speakers from the list."""
         hidden = create_talk_type('Hidden')
@@ -525,6 +526,7 @@ class SpeakerTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('Hidden', response.context["speaker_rows"])
 
+    @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_ordering_types(self):
         """Test that we order the speakers according to the talk type correctly"""
         test1 = create_talk_type('Test 1')

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -409,9 +409,12 @@ class SpeakerTests(TestCase):
     @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_multiple_types(self):
         """Test the view for multiple talk types"""
-        talk_d = create_talk('Talk D', ACCEPTED, 'author_d', self.talk_type1)
-        talk_e = create_talk('Talk E', ACCEPTED, 'author_e', self.talk_type1)
-        keynote_f = create_talk('Talk F', ACCEPTED, 'author_f', self.talk_type2)
+        talk_d = create_talk('Talk D', ACCEPTED, 'author_d',
+                             talk_type=self.talk_type1)
+        talk_e = create_talk('Talk E', ACCEPTED, 'author_e',
+                             talk_type=self.talk_type1)
+        keynote_f = create_talk('Talk F', ACCEPTED, 'author_f',
+                                talk_type=self.talk_type2)
 
         user_d = talk_d.corresponding_author
         user_e = talk_e.corresponding_author
@@ -510,7 +513,7 @@ class SpeakerTests(TestCase):
     def test_exluding_types(self):
         """Test that the show_speakers flag excludes the speakers from the list."""
         hidden = create_talk_type('Hidden')
-        talk_d = create_talk('Talk D', ACCEPTED, 'author_d', hidden)
+        talk_d = create_talk('Talk D', ACCEPTED, 'author_d', talk_type=hidden)
 
         response = self.client.get(
             reverse('wafer_talks_speakers'))
@@ -538,8 +541,8 @@ class SpeakerTests(TestCase):
         test2.order = 2
         test2.save()
 
-        talk_d = create_talk('Talk D', ACCEPTED, 'author_d', test1)
-        talk_e = create_talk('Talk D', ACCEPTED, 'author_e', test2)
+        talk_d = create_talk('Talk D', ACCEPTED, 'author_d', talk_type=test1)
+        talk_e = create_talk('Talk D', ACCEPTED, 'author_e', talk_type=test2)
         response = self.client.get(
             reverse('wafer_talks_speakers'))
         types = list(response.context['speaker_rows'])

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -6,17 +6,11 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from wafer.tests.api_utils import SortedResultsClient
-from wafer.tests.utils import create_user
+from wafer.tests.utils import create_user, mock_avatar_url
 from wafer.talks.models import (
     Talk, TalkUrl, ACCEPTED, REJECTED, SUBMITTED, UNDER_CONSIDERATION,
     CANCELLED, PROVISIONAL)
 from wafer.talks.tests.fixtures import create_talk, create_talk_type
-
-
-def mock_avatar_url(self):
-    if self.user.email is None:
-        return None
-    return "avatar-%s" % self.user.email
 
 
 class UsersTalksTests(TestCase):

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -8,28 +8,9 @@ from django.urls import reverse
 from wafer.tests.api_utils import SortedResultsClient
 from wafer.tests.utils import create_user
 from wafer.talks.models import (
-    Talk, TalkUrl, TalkType, ACCEPTED, REJECTED, SUBMITTED,
-    UNDER_CONSIDERATION, CANCELLED, PROVISIONAL)
-
-
-def create_talk_type(name):
-    """Create a talk type"""
-    return TalkType.objects.create(name=name)
-
-
-
-def create_talk(title, status, username, talk_type=None):
-    user = create_user(username)
-    talk = Talk.objects.create(
-        title=title, status=status, corresponding_author_id=user.id)
-    talk.authors.add(user)
-    talk.notes = "Some notes for talk %s" % title
-    talk.private_notes = "Some private notes for talk %s" % title
-    talk.save()
-    if talk_type:
-        talk.talk_type = talk_type
-        talk.save()
-    return talk
+    Talk, TalkUrl, ACCEPTED, REJECTED, SUBMITTED, UNDER_CONSIDERATION,
+    CANCELLED, PROVISIONAL)
+from wafer.talks.tests.fixtures import create_talk, create_talk_type
 
 
 def mock_avatar_url(self):

--- a/wafer/talks/tests/test_wafer_basic_talks.py
+++ b/wafer/talks/tests/test_wafer_basic_talks.py
@@ -4,12 +4,12 @@ from django.contrib.auth import get_user_model
 from django.utils.timezone import datetime, now, utc
 
 from wafer.talks.models import Talk, TalkType
+from wafer.tests.utils import create_user
 
 
 def test_add_talk():
     """Create a user and add a talk to it"""
-    user = get_user_model().objects.create_user('john', 'best@wafer.test',
-                                                'johnpassword')
+    user = create_user('john')
     Talk.objects.create(
         title="This is a test talk",
         abstract="This should be a long and interesting abstract, but isn't",
@@ -20,10 +20,9 @@ def test_add_talk():
 
 def test_filter_talk():
     """Create a second user and check some filters"""
+    create_user('james')
+
     UserModel = get_user_model()
-
-    UserModel.objects.create_user('james', 'best@wafer.test', 'johnpassword')
-
     assert UserModel.objects.filter(contact_talks__isnull=False).count() == 1
     assert UserModel.objects.filter(contact_talks__isnull=True).count() == 1
 
@@ -53,16 +52,12 @@ def test_multiple_talks():
 
 def test_corresponding_author_details():
     """Create a second user and check some filters"""
-    UserModel = get_user_model()
-
-    user = UserModel.objects.create_user('jeff', 'best@wafer.test',
-                                         'johnpassword')
+    user = create_user('jeff')
     profile = user.userprofile
     profile.contact_number = '77776'
     profile.save()
 
-    speaker = UserModel.objects.create_user('bob', 'bob@wafer.test',
-                                            'bobpassword')
+    speaker = create_user('bob')
 
     Talk.objects.create(
         title="This is a another test talk",
@@ -75,7 +70,7 @@ def test_corresponding_author_details():
     talk.save()
 
     assert talk.get_authors_display_name() == 'jeff & bob'
-    assert talk.get_corresponding_author_contact() == 'best@wafer.test - 77776'
+    assert talk.get_corresponding_author_contact() == 'jeff@example.com - 77776'
     assert talk.get_corresponding_author_name() == 'jeff (jeff)'
 
     speaker.first_name = 'Bob'

--- a/wafer/talks/tests/test_wafer_basic_talks.py
+++ b/wafer/talks/tests/test_wafer_basic_talks.py
@@ -3,17 +3,15 @@
 from django.contrib.auth import get_user_model
 from django.utils.timezone import datetime, now, utc
 
-from wafer.talks.models import Talk, TalkType
+from wafer.talks.models import Talk, TalkType, SUBMITTED
+from wafer.talks.tests.fixtures import create_talk
 from wafer.tests.utils import create_user
 
 
 def test_add_talk():
     """Create a user and add a talk to it"""
     user = create_user('john')
-    Talk.objects.create(
-        title="This is a test talk",
-        abstract="This should be a long and interesting abstract, but isn't",
-        corresponding_author_id=user.id)
+    create_talk('This is a test talk', status=SUBMITTED, user=user)
 
     assert user.contact_talks.count() == 1
 
@@ -34,18 +32,12 @@ def test_multiple_talks():
     user1 = UserModel.objects.filter(username='john').get()
     user2 = UserModel.objects.filter(username='james').get()
 
-    Talk.objects.create(
-        title="This is a another test talk",
-        abstract="This should be a long and interesting abstract, but isn't",
-        corresponding_author_id=user1.id)
+    create_talk('This is a another test talk', status=SUBMITTED, user=user1)
 
     assert len([x.title for x in user1.contact_talks.all()]) == 2
     assert len([x.title for x in user2.contact_talks.all()]) == 0
 
-    Talk.objects.create(
-        title="This is a third test talk",
-        abstract="This should be a long and interesting abstract, but isn't",
-        corresponding_author_id=user2.id)
+    create_talk('This is a third test talk', status=SUBMITTED, user=user2)
 
     assert len([x.title for x in user2.contact_talks.all()]) == 1
 
@@ -59,10 +51,7 @@ def test_corresponding_author_details():
 
     speaker = create_user('bob')
 
-    Talk.objects.create(
-        title="This is a another test talk",
-        abstract="This should be a long and interesting abstract, but isn't",
-        corresponding_author_id=user.id)
+    create_talk('This is a another test talk', status=SUBMITTED, user=user)
 
     talk = user.contact_talks.all()[0]
     talk.authors.add(user)

--- a/wafer/talks/tests/test_wafer_basic_talks.py
+++ b/wafer/talks/tests/test_wafer_basic_talks.py
@@ -1,11 +1,13 @@
 # This tests the very basic talk stuff, to ensure some levels of sanity
 
+from django.contrib.auth import get_user_model
+from django.utils.timezone import datetime, now, utc
+
+from wafer.talks.models import Talk, TalkType
+
 
 def test_add_talk():
     """Create a user and add a talk to it"""
-    from django.contrib.auth import get_user_model
-    from wafer.talks.models import Talk
-
     user = get_user_model().objects.create_user('john', 'best@wafer.test',
                                                 'johnpassword')
     Talk.objects.create(
@@ -18,8 +20,6 @@ def test_add_talk():
 
 def test_filter_talk():
     """Create a second user and check some filters"""
-    from django.contrib.auth import get_user_model
-
     UserModel = get_user_model()
 
     UserModel.objects.create_user('james', 'best@wafer.test', 'johnpassword')
@@ -30,9 +30,6 @@ def test_filter_talk():
 
 def test_multiple_talks():
     """Add more talks"""
-    from wafer.talks.models import Talk
-    from django.contrib.auth import get_user_model
-
     UserModel = get_user_model()
 
     user1 = UserModel.objects.filter(username='john').get()
@@ -56,9 +53,6 @@ def test_multiple_talks():
 
 def test_corresponding_author_details():
     """Create a second user and check some filters"""
-    from django.contrib.auth import get_user_model
-    from wafer.talks.models import Talk
-
     UserModel = get_user_model()
 
     user = UserModel.objects.create_user('jeff', 'best@wafer.test',
@@ -92,15 +86,10 @@ def test_corresponding_author_details():
 
 
 def test_is_late_submission_no_talk_type():
-    from wafer.talks.models import Talk
-
     assert not Talk().is_late_submission
 
 
 def test_is_late_submission_no_deadline():
-    from django.utils.timezone import now
-    from wafer.talks.models import Talk, TalkType
-
     talk_type = TalkType()
     talk = Talk(submission_time=now(), talk_type=talk_type)
 
@@ -108,9 +97,6 @@ def test_is_late_submission_no_deadline():
 
 
 def test_is_late_submission_not_late():
-    from django.utils.timezone import datetime, utc
-    from wafer.talks.models import Talk, TalkType
-
     deadline = datetime(2019, 11, 1, 0, 0, 0, 0, utc)
     before_deadline = datetime(2019, 10, 15, 0, 0, 0, 0, utc)
 
@@ -120,9 +106,6 @@ def test_is_late_submission_not_late():
 
 
 def test_is_late_submission_late():
-    from django.utils.timezone import datetime, utc
-    from wafer.talks.models import Talk, TalkType
-
     deadline = datetime(2019, 11, 1, 0, 0, 0, 0, utc)
     after_deadline = datetime(2019, 11, 2, 0, 0, 0, 0, utc)
 

--- a/wafer/tests/utils.py
+++ b/wafer/tests/utils.py
@@ -18,3 +18,10 @@ def create_user(username, email=None, superuser=False, perms=()):
     if perms:
         user = get_user_model().objects.get(pk=user.pk)
     return user
+
+
+def mock_avatar_url(self):
+    """Avoid libravatar DNS lookups during tests"""
+    if self.user.email is None:
+        return None
+    return "avatar-%s" % self.user.email

--- a/wafer/tests/utils.py
+++ b/wafer/tests/utils.py
@@ -1,10 +1,10 @@
 """Utilities for testing wafer."""
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 
 
-def create_user(username, email=None, superuser=False, perms=()):
+def create_user(username, email=None, superuser=False, perms=(), groups=()):
     if superuser:
         create = get_user_model().objects.create_superuser
     else:
@@ -15,7 +15,10 @@ def create_user(username, email=None, superuser=False, perms=()):
     for codename in perms:
         perm = Permission.objects.get(codename=codename)
         user.user_permissions.add(perm)
-    if perms:
+    for group_name in groups:
+        group = Group.objects.get(name=group_name)
+        user.groups.add(group)
+    if perms or groups:
         user = get_user_model().objects.get(pk=user.pk)
     return user
 

--- a/wafer/users/tests/test_models.py
+++ b/wafer/users/tests/test_models.py
@@ -2,16 +2,13 @@
 # vim:fileencoding=utf-8 ai ts=4 sts=4 et sw=4
 """Tests for wafer.user.models"""
 
-from django.contrib.auth import get_user_model
 from django.test import TestCase
+from wafer.tests.utils import create_user
 
 
 class UserModelTestCase(TestCase):
 
     def test_str_method_issue192(self):
         """Test that str(user) works correctly"""
-        create = get_user_model().objects.create_user
-        user = create('test', 'test@example.com', 'test_pass')
+        user = create_user('test')
         self.assertEqual(str(user.userprofile), 'test')
-        user = create(u'tést', 'test@example.com', 'test_pass')
-        self.assertEqual(str(user.userprofile), u'tést')

--- a/wafer/users/tests/test_views.py
+++ b/wafer/users/tests/test_views.py
@@ -4,21 +4,19 @@
 
 import mock
 
-from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 
 from wafer.talks.models import Talk, ACCEPTED
-from wafer.tests.utils import mock_avatar_url
+from wafer.tests.utils import create_user, mock_avatar_url
 
 
 class UserProfileTests(TestCase):
 
     def setUp(self):
-        create = get_user_model().objects.create_user
         # Create 2 users
-        create("test1", "test@example.com", "test_password")
-        create("test2", "test@example.com", "test_password")
-        user3 = create("test3", "test@example.com", "test_password")
+        create_user('test1')
+        create_user('test2')
+        user3 = create_user('test3')
         talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
                                    corresponding_author_id=user3.id)
         talk.authors.add(user3)
@@ -56,7 +54,7 @@ class UserProfileTests(TestCase):
            non-existing users.
 
            We can see the user with an accepted talk, but not edit."""
-        self.client.login(username='test1', password="test_password")
+        self.client.login(username='test1', password="test1_password")
         with self.settings(WAFER_PUBLIC_ATTENDEE_LIST=False):
             response = self.client.get('/users/test1/')
             self.assertEqual(response.status_code, 200)
@@ -111,7 +109,7 @@ class UserProfileTests(TestCase):
            We should be able to access other profiles, but not edit them.
 
            we should get 404's for non-existing users."""
-        self.client.login(username='test1', password="test_password")
+        self.client.login(username='test1', password="test1_password")
         with self.settings(WAFER_PUBLIC_ATTENDEE_LIST=True):
             response = self.client.get('/users/test1/')
             self.assertEqual(response.status_code, 200)

--- a/wafer/users/tests/test_views.py
+++ b/wafer/users/tests/test_views.py
@@ -2,9 +2,13 @@
 # vim:fileencoding=utf-8 ai ts=4 sts=4 et sw=4
 """Tests for wafer.user.views"""
 
+import mock
+
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
+
 from wafer.talks.models import Talk, ACCEPTED
+from wafer.tests.utils import mock_avatar_url
 
 
 class UserProfileTests(TestCase):
@@ -20,6 +24,7 @@ class UserProfileTests(TestCase):
         talk.authors.add(user3)
         self.client = Client()
 
+    @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_not_logged_in_private_userlist(self):
         """We should get 403 for both existing and non-existant users.
 
@@ -45,6 +50,7 @@ class UserProfileTests(TestCase):
             response = self.client.get('/users/does_not_exist/edit_profile/')
             self.assertEqual(response.status_code, 403)
 
+    @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_logged_in_private_userlist(self):
         """We can see and edit our own profile, but get 403's for existing and
            non-existing users.
@@ -72,6 +78,7 @@ class UserProfileTests(TestCase):
             response = self.client.get('/users/does_not_exist/edit_profile/')
             self.assertEqual(response.status_code, 403)
 
+    @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_not_logged_in_public_userlist(self):
         """We should be able to access profiles, but not edit them.
 
@@ -98,6 +105,7 @@ class UserProfileTests(TestCase):
             response = self.client.get('/users/does_not_exist/edit_profile/')
             self.assertEqual(response.status_code, 404)
 
+    @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)
     def test_logged_in_pulic_userlist(self):
         """We should be able to edit our profile.
            We should be able to access other profiles, but not edit them.

--- a/wafer/users/tests/test_views.py
+++ b/wafer/users/tests/test_views.py
@@ -6,7 +6,8 @@ import mock
 
 from django.test import Client, TestCase
 
-from wafer.talks.models import Talk, ACCEPTED
+from wafer.talks.models import ACCEPTED
+from wafer.talks.tests.fixtures import create_talk
 from wafer.tests.utils import create_user, mock_avatar_url
 
 
@@ -16,10 +17,8 @@ class UserProfileTests(TestCase):
         # Create 2 users
         create_user('test1')
         create_user('test2')
-        user3 = create_user('test3')
-        talk = Talk.objects.create(title="Test talk", status=ACCEPTED,
-                                   corresponding_author_id=user3.id)
-        talk.authors.add(user3)
+        # And a 3rd, with a talk
+        create_talk(title="Test talk", status=ACCEPTED, username='test3')
         self.client = Client()
 
     @mock.patch('wafer.users.models.UserProfile.avatar_url', mock_avatar_url)


### PR DESCRIPTION
Use `create_user()` and `create_talk()` where possible in tests, eliminating some boilerplate.

Also, mock out a few libravatar calls that can slow down tests and require Internet connectivity.