### PR TITLE
frab XML: Emit <day start=... end=...> attributes

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -20,7 +20,7 @@
     <acronym>{{ WAFER_CONFERENCE_ACRONYM }}</acronym>
   </conference>
   {% for page in schedule_pages %}
-    <day date="{{ page.block.start_time|date:'Y-m-d' }}" index="{{ forloop.counter }}">
+    <day date="{{ page.block.start_time.date.isoformat }}" start="{{ page.block.start_time.isoformat }}" end="{{ page.block.end_time.isoformat }}" index="{{ forloop.counter }}">
       {% for venue in page.venues %}
         <room name="{{ venue.name }}">
           {% for row in page.rows %}


### PR DESCRIPTION
EventFahrplan requires them to be present, even though the XSD doesn't (ATM)

See: https://github.com/voc/schedule/issues/87