### PR TITLE
Use static GUIDs in the frab schedule, when possible

### DIFF
--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -356,13 +356,15 @@ class ScheduleItem(models.Model):
 
     @property
     def guid(self):
-        """Return a GUID for the ScheduleItem (for frab xml)"""
+        """Return a GUID for the ScheduleItem (for frab xml)
+
+        We return static GUIDs across re-scheduling, when possible.
+        """
         if self.talk:
-            # Talks can only appear once in the schedule, they get a static ID
             id_ = 'talk:' + str(self.talk.pk)
+        elif self.page and self.page.scheduleitem_set.count() == 1:
+            id_ = 'page:' + str(self.page.pk)
         else:
-            # Other things can appear multiple times, they get the schedule
-            # item ID to avoid duplicate IDs
             id_ = 'schedule_item:' + str(self.pk)
         hmac = salted_hmac('wafer-event-uuid', id_)
         return UUID(bytes=hmac.digest()[:16])

--- a/wafer/schedule/models.py
+++ b/wafer/schedule/models.py
@@ -357,7 +357,14 @@ class ScheduleItem(models.Model):
     @property
     def guid(self):
         """Return a GUID for the ScheduleItem (for frab xml)"""
-        hmac = salted_hmac('wafer-event-uuid', str(self.pk))
+        if self.talk:
+            # Talks can only appear once in the schedule, they get a static ID
+            id_ = 'talk:' + str(self.talk.pk)
+        else:
+            # Other things can appear multiple times, they get the schedule
+            # item ID to avoid duplicate IDs
+            id_ = 'schedule_item:' + str(self.pk)
+        hmac = salted_hmac('wafer-event-uuid', id_)
         return UUID(bytes=hmac.digest()[:16])
 
 

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -28,7 +28,9 @@
               {# this is more than a little horrible, but will do for testing #}
               {% for row_venue, items in row.items.items %}
                 {% if row_venue == venue and items.item %}
-                  {# The event id is the ScheduleItem pk, which should be unique enough #}
+                  {# The event id is the ScheduleItem pk, which should be unique #}
+                  {# enough, but changes if the event is rescheduled. #}
+                  {# Talks' guid will be stable across re-scheduling. #}
                   <event id="{{ items.item.pk }}" guid="{{ items.item.guid }}">
                     <date>{{ row.start_time.isoformat }}</date>
                     <start>{{ row.start_time|time:"H:i" }}</start>

--- a/wafer/schedule/tests/test_models.py
+++ b/wafer/schedule/tests/test_models.py
@@ -471,3 +471,34 @@ class LastUpdateTests(TestCase):
                 # No other items should have changed, as time changes don't
                 # cascade that way
                 self.assertEqual(item.last_updated, update_times[item.pk])
+
+
+class ScheduleItemGUIDTests(TestCase):
+    def setUp(self):
+        venue1 = Venue.objects.create(order=1, name='Venue 1')
+        self.venues = [venue1]
+
+    def test_unique_guid(self):
+        """Test that the all guids are unique."""
+        pages = make_pages(2)
+        items = make_items(self.venues * 2, pages)
+
+        guids = set(item.guid for item in items)
+        self.assertEqual(len(guids), len(items))
+
+    def test_rescheduled_page_keeps_guid(self):
+        """A page that's in the schedule once keeps its guid when rescheduled"""
+        pages = make_pages(2)
+        items = make_items(self.venues * 2, pages)
+        guid = items[0].guid
+        # Reschedule
+        for item in items:
+            item.delete()
+        items = make_items(self.venues, pages)
+        self.assertEqual(guid, items[0].guid)
+
+    def test_double_scheduled_page_has_unique_guid(self):
+        """A page that's in the schedule twice has a unique GUID per instance"""
+        pages = make_pages(1)
+        items = make_items(self.venues * 2, pages * 2)
+        self.assertNotEqual(items[0].guid, items[1].guid)


### PR DESCRIPTION
SReview is currently having to use the integer in the talk URL to track talks, as they move around in the schedule. There should be a better way.
https://salsa.debian.org/debconf-video-team/sreview/-/blob/main/scripts/util/schedule_parsers/debconf#L82

The frab XSD defines `<event>`'s `id` attribute as being an integer, in a single namespace. To avoid duplicates (because Pages and Talks are separate DB entities in wafer, with their own ID space), we've used the `ScheduleItem`'s ID in the past. But these change when a talk gets rescheduled.

So, let's put more information into the GUID. There's enough room here to namespace kinds of schedule items from each other.

I could also imagine putting Talks, Pages, and other ScheduleItems in separate integer ranges (e.g. 0-10000 for talks, 10000-20000 for pages, etc.), but that gets somewhat hairy. This has the advantage of being simple.

Downside is that the consumer can't determine the talk's integer ID from the XML. There doesn't seem to be an appropriate attribute to share it in. Probably the best option will be to continue to parse the XML.