### PR TITLE
Fix /schedule/current when the schedule spans midnight

### DIFF
--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -1047,9 +1047,7 @@ class CurrentViewTests(TestCase):
             item.slots.add(slots[index // 2])
 
         c = Client()
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur1.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur1.isoformat()})
         context = response.context
 
         assert context['cur_slot'] == slots[0]
@@ -1059,9 +1057,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][0].items[venue1]['note'] == 'current'
         assert context['slots'][1].items[venue1]['note'] == 'forthcoming'
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur2.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur2.isoformat()})
         context = response.context
         assert context['cur_slot'] == slots[1]
         assert len(context['schedule_page'].venues) == 2
@@ -1071,9 +1067,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][1].items[venue1]['note'] == 'current'
         assert context['slots'][2].items[venue1]['note'] == 'forthcoming'
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur3.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur3.isoformat()})
         context = response.context
         assert context['cur_slot'] == slots[2]
         assert len(context['schedule_page'].venues) == 2
@@ -1083,9 +1077,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][1].items[venue1]['note'] == 'current'
         assert context['slots'][2].items[venue1]['note'] == 'forthcoming'
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur4.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur4.isoformat()})
         context = response.context
         assert context['cur_slot'] == slots[3]
         assert len(context['schedule_page'].venues) == 2
@@ -1094,9 +1086,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][0].items[venue1]['note'] == 'complete'
         assert context['slots'][1].items[venue1]['note'] == 'current'
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur5.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur5.isoformat()})
         context = response.context
         assert context['cur_slot'] is None
         assert len(context['schedule_page'].venues) == 2
@@ -1106,8 +1096,7 @@ class CurrentViewTests(TestCase):
 
         # Check that next day is an empty current view
         response = c.get('/schedule/current/',
-                         {'day': day2.start_time.strftime('%Y-%m-%d'),
-                          'time': cur3.strftime('%H:%M')})
+            {'timestamp': (cur3 + D.timedelta(days=1)).isoformat()})
         assert len(response.context['slots']) == 0
 
     def test_current_view_complex(self):
@@ -1174,9 +1163,7 @@ class CurrentViewTests(TestCase):
         cur4 = D.datetime(2013, 9, 22, 14, 30, 0, tzinfo=timezone.utc)
 
         c = Client()
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur1.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur1.isoformat()})
         context = response.context
         assert context['cur_slot'] == slot1
         assert len(context['schedule_page'].venues) == 3
@@ -1185,9 +1172,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][0].items[venue1]['colspan'] == 1
         assert context['slots'][0].items[venue2]['item'] is None
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur2.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur2.isoformat()})
         context = response.context
         assert context['cur_slot'] == slot2
         assert len(context['slots']) == 3
@@ -1200,9 +1185,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][2].items[venue2]['note'] == 'forthcoming'
         assert context['slots'][2].items[venue2]['rowspan'] == 1
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur3.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur3.isoformat()})
         context = response.context
         assert context['cur_slot'] == slot3
         assert len(context['slots']) == 3
@@ -1213,9 +1196,7 @@ class CurrentViewTests(TestCase):
         assert context['slots'][1].items[venue2]['note'] == 'current'
         assert context['slots'][1].items[venue2]['rowspan'] == 2
 
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur4.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur4.isoformat()})
         context = response.context
         assert context['cur_slot'] == slot5
         assert len(context['slots']) == 2
@@ -1272,12 +1253,12 @@ class CurrentViewTests(TestCase):
         items[9].slots.add(slot5)
 
         # During the first slot
-        cur1 = D.time(10, 30, 0)
+        cur1 = D.datetime(2013, 9, 22, 10, 30, 0)
         # Middle of the day
-        cur2 = D.time(11, 30, 0)
-        cur3 = D.time(12, 30, 0)
+        cur2 = D.datetime(2013, 9, 22, 11, 30, 0)
+        cur3 = D.datetime(2013, 9, 22, 12, 30, 0)
         # During the last slot
-        cur4 = D.time(14, 30, 0)
+        cur4 = D.datetime(2013, 9, 22, 14, 30, 0)
 
         def validate_current(response):
             """Validate that the current view is still has the expected content"""
@@ -1295,23 +1276,19 @@ class CurrentViewTests(TestCase):
 
         c = Client()
         # Check that we don't highlight if not asked
-        response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur2.strftime('%H:%M')})
+        response = c.get('/schedule/current/', {'timestamp': cur2.isoformat()})
         validate_current(response)
         self.assertNotContains(response, b'schedule-highlight-venue')
         # Check with invalid venue
         response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur2.strftime('%H:%M'),
+                         {'timestamp': cur2.isoformat(),
                           'highlight-venue': 'aaaa'})
         validate_current(response)
         self.assertNotContains(response, b'schedule-highlight-venue')
 
         # Check with venue 1
         response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur2.strftime('%H:%M'),
+                         {'timestamp': cur2.isoformat(),
                           'highlight-venue': '%d' % venue1.pk})
         validate_current(response)
         self.assertContains(response, b'schedule-highlight-venue')
@@ -1359,8 +1336,7 @@ class CurrentViewTests(TestCase):
 
         # Check with venue 3
         response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur2.strftime('%H:%M'),
+                         {'timestamp': cur2.isoformat(),
                           'highlight-venue': '%d' % venue3.pk})
         validate_current(response)
         self.assertContains(response, b'schedule-highlight-venue')
@@ -1436,8 +1412,7 @@ class CurrentViewTests(TestCase):
 
         c = Client()
         response = c.get('/schedule/current/',
-                         {'day': day1.start_time.strftime('%Y-%m-%d'),
-                          'time': cur1.strftime('%H:%M')})
+                         {'timestamp': cur1.isoformat()})
         assert response.context['active'] is False
 
 

--- a/wafer/schedule/views.py
+++ b/wafer/schedule/views.py
@@ -6,6 +6,7 @@ import logging
 from icalendar import Calendar, Event
 
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models import Q
@@ -219,37 +220,30 @@ class ScheduleXmlView(ScheduleView):
 class CurrentView(TemplateView):
     template_name = 'wafer.schedule/current.html'
 
-    def _parse_today(self, day, time):
-        if day is None:
-            day = datetime.date.today()
-        else:
-            day = datetime.datetime.strptime(day, '%Y-%m-%d').date()
-        if time is None:
-            time = datetime.datetime.now().time()
-        else:
-            time = datetime.datetime.strptime(time, '%H:%M').time()
-        full_time = datetime.datetime.combine(day, time)
-        tz = timezone.get_default_timezone()
-        timestamp = timezone.make_aware(full_time, tz)
+    def _parse_timestamp(self, timestamp):
+        """
+        Parse a user provided timestamp query string parameter.
+        Return a TZ aware datetime, or None.
+        """
+        if not timestamp:
+            return None
+        try:
+            timestamp = parse_datetime(timestamp)
+        except ValueError as e:
+            messages.error(self.request,
+                           'Failed to parse timestamp: %s' % e)
+        if timestamp is None:
+            messages.error(self.request, 'Failed to parse timestamp')
+            return None
+        if not timezone.is_aware(timestamp):
+            timestamp = timezone.make_aware(timestamp)
+        return timestamp
+
+    def _get_schedule_page(self, timestamp):
         for candidate in ScheduleBlock.objects.all():
             if candidate.start_time < timestamp < candidate.end_time:
                 return SchedulePage(candidate)
         return None
-
-    def _parse_time(self, day, time):
-        tz = timezone.get_default_timezone()
-        now = timezone.make_aware(datetime.datetime.now(), tz)
-        if day is None:
-            return now
-        if time is None:
-            return now
-        try:
-            full_time = datetime.datetime.combine(datetime.datetime.strptime(day, "%Y-%m-%d").date(),
-                                                  datetime.datetime.strptime(time, '%H:%M').time())
-            return timezone.make_aware(full_time, tz)
-        except ValueError:
-            pass
-        return now
 
     def _add_note(self, row, note, overlap_note):
         for item in row.items.values():
@@ -307,20 +301,23 @@ class CurrentView(TemplateView):
         context['slots'] = []
         # Allow refresh time to be overridden
         context['refresh'] = self.request.GET.get('refresh', None)
+
+        # Allow the current time to be overridden, mostly for testing
+        timestamp = self._parse_timestamp(
+                self.request.GET.get('timestamp', None)) or timezone.now()
+
+        schedule_page = self._get_schedule_page(timestamp)
         # If there are no items scheduled for today, return an empty slots list
-        schedule_page = self._parse_today(self.request.GET.get('day', None), self.request.GET.get('time', None))
         if schedule_page is None:
             return context
         context['schedule_page'] = schedule_page
-        # Allow current time to be overridden
-        time = self._parse_time(self.request.GET.get('day', None), self.request.GET.get('time', None))
 
         highlight_venue = lookup_highlighted_venue(self.request)
         context['highlight_venue_pk'] = -1
         if highlight_venue is not None:
             context['highlight_venue_pk'] = highlight_venue
 
-        cur_slot, current_rows = self._current_slots(schedule_page, time)
+        cur_slot, current_rows = self._current_slots(schedule_page, timestamp)
         context['cur_slot'] = cur_slot
         context['slots'].extend(current_rows)
 


### PR DESCRIPTION
When a schedule spans midnight, `/schedule/current` displays the last talk from the previous day, every day.
It's still based on the old separate date and time from ScheduleDay and ScheduleBlock, in its logic, the migration was incomplete here.

Fix the bug, and refactor the code to use a single `timestamp` query parameter for testing.