### PR TITLE
Force default to None if the list of allowed languages is empty

### DIFF
--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -165,7 +165,7 @@ class Talk(models.Model):
 
     LANGUAGES = settings.WAFER_TALK_LANGUAGES
     # DEFAULT_LANGUAGE should be None if WAFER_TALK_LANGUAGES is empty
-    DEFAULT_LANGUAGE = LANGUAGES and LANGUAGES[0][0] or None
+    DEFAULT_LANGUAGE = LANGUAGES[0][0] if LANGUAGES else None
     language = models.CharField(
         verbose_name=_("language"),
         max_length=5,

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -164,7 +164,8 @@ class Talk(models.Model):
         Track, verbose_name=_("track"), null=True, blank=True, on_delete=models.SET_NULL)
 
     LANGUAGES = settings.WAFER_TALK_LANGUAGES
-    DEFAULT_LANGUAGE = LANGUAGES and LANGUAGES[0][0]
+    # DEFAULT_LANGUAGE should be None if WAFER_TALK_LANGUAGES is empty
+    DEFAULT_LANGUAGE = LANGUAGES and LANGUAGES[0][0] or None
     language = models.CharField(
         verbose_name=_("language"),
         max_length=5,


### PR DESCRIPTION
If the language list in settings is left at the default in the settings file, the default value in the database is set to '()', while the list of legal choices is empty. This results in the individual talk admin form being somewhat annoying to use, - unless the language field is explicitly deleted, the admin form will error out with "Select a valid choice. () is not one of the available choices." when a change is made.

This change sets the default to None in this case, which is more appropriate behaviour.

We could also change the default for WAFER_TALK_LANGUAGES to be None in the settings file, but there is value in keeping the hint that this should be a tuple there.