### PR TITLE
Specify folder to install the django.mo file in.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
     include_package_data=True,
     install_requires=REQUIRES,
     dependency_links=SOURCES,
-    data_files=compile_translations(),
+    data_files=[
+        ('locale', compile_translations()),
+    ],
     setup_requires=[
         # Add setuptools-git, so we get correct behaviour for
         # include_package_data


### PR DESCRIPTION
This prevents the warning:
```
warning: install_data: setup script did not provide a directory for 'wafer/locale/it/LC_MESSAGES/django.mo' -- installing right in 'build/bdist.linux-x86_64/wheel/wafer-0.12.0.data/data'
```
when running `python setup.py bdist_wheel`.

See https://docs.python.org/3/distutils/setupscript.html#installing-additional-files.

However, I'm not sure what the right folder to specify is. Does anything use `django.mo` directly?