### PR TITLE
Use spaceless to reduce strange whitespace in the sponsor template

### DIFF
--- a/wafer/sponsors/templates/wafer.sponsors/sponsors_footer.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors_footer.html
@@ -1,10 +1,10 @@
 {% load sponsors %}
 <div id="wafer-sponsors" class="container">
-  {% spaceless %}
-    {% for package in packages %}
-      {% if package.sponsors.exists %}
-        {% for sponsor in package.sponsors.all %}
-          {% sponsor_tagged_image sponsor "footer_logo" as logo_url %}
+  {% for package in packages %}
+    {% if package.sponsors.exists %}
+      {% for sponsor in package.sponsors.all %}
+        {% sponsor_tagged_image sponsor "footer_logo" as logo_url %}
+          {% spaceless %}
           <a href="{{ sponsor.url }}">
             {% if logo_url != '' %}
               <img src="{{ logo_url }}"
@@ -15,9 +15,9 @@
               <span class="nologo">{{ sponsor.name }}</span>
             {% endif %}
           </a>
-        {% endfor %}
-        <br>
-      {% endif %}
-    {% endfor %}
-  {% endspaceless %}
+          {% endspaceless %}
+      {% endfor %}
+      <br>
+    {% endif %}
+  {% endfor %}
 </div>

--- a/wafer/sponsors/templates/wafer.sponsors/sponsors_footer.html
+++ b/wafer/sponsors/templates/wafer.sponsors/sponsors_footer.html
@@ -1,21 +1,23 @@
 {% load sponsors %}
 <div id="wafer-sponsors" class="container">
-  {% for package in packages %}
-    {% if package.sponsors.exists %}
-      {% for sponsor in package.sponsors.all %}
-        {% sponsor_tagged_image sponsor "footer_logo" as logo_url %}
-        <a href="{{ sponsor.url }}">
-          {% if logo_url != '' %}
-            <img src="{{ logo_url }}"
-                 alt="{{ sponsor.name }}"
-                 style="max-width: 200px; max-height:100px;"
-                 title="{{ sponsor.name }}">
-          {% else %}
-            <span class="nologo">{{ sponsor.name }}</span>
-          {% endif %}
-        </a>
-      {% endfor %}
-      <br>
-    {% endif %}
-  {% endfor %}
+  {% spaceless %}
+    {% for package in packages %}
+      {% if package.sponsors.exists %}
+        {% for sponsor in package.sponsors.all %}
+          {% sponsor_tagged_image sponsor "footer_logo" as logo_url %}
+          <a href="{{ sponsor.url }}">
+            {% if logo_url != '' %}
+              <img src="{{ logo_url }}"
+                   alt="{{ sponsor.name }}"
+                   style="max-width: 200px; max-height:100px;"
+                   title="{{ sponsor.name }}">
+            {% else %}
+              <span class="nologo">{{ sponsor.name }}</span>
+            {% endif %}
+          </a>
+        {% endfor %}
+        <br>
+      {% endif %}
+    {% endfor %}
+  {% endspaceless %}
 </div>


### PR DESCRIPTION
We're fairly lax about using Django's options for stripping whitespace from our templates, which can cause issues with styling stuff. This makes the sponsor block less full of random newlines and various spacing.