### PR TITLE
Switch to slots.set to support recent Django behaviour

### DIFF
--- a/wafer/schedule/serializers.py
+++ b/wafer/schedule/serializers.py
@@ -37,7 +37,7 @@ class ScheduleItemSerializer(serializers.HyperlinkedModelSerializer):
         else:
             existing_schedule_item.talk = talk
             existing_schedule_item.page = page
-            existing_schedule_item.slots = slots
+            existing_schedule_item.slots.set(slots)
             # Clear any existing details that aren't editable by the
             # schedule edit view
             existing_schedule_item.details = ''


### PR DESCRIPTION
This fixes the current breakage of the schedule editor "Direct assignment to the forward side of a many-to-many set is prohibited."

Works correctly with local testing with Django 3.0, but we should add better tests to this API at some point.