### PR TITLE
Explicitly convert schedule times to event local time

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 {% load i18n %}
 {% load tz %}
-{% localtime on %}
 <schedule>
   <generator name="wafer" version="{{ wafer_version }}" />
   <version>{{ schedule_version }}</version>
@@ -129,4 +128,3 @@
     </day>
   {% endfor %}
 </schedule>
-{% endlocaltime %}

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 {% load i18n %}
+{% load tz %}
+{% localtime on %}
 <schedule>
   <generator name="wafer" version="{{ wafer_version }}" />
   <version>{{ schedule_version }}</version>
@@ -20,7 +22,7 @@
     <acronym>{{ WAFER_CONFERENCE_ACRONYM }}</acronym>
   </conference>
   {% for page in schedule_pages %}
-    <day date="{{ page.block.start_time.date.isoformat }}" start="{{ page.block.start_time.isoformat }}" end="{{ page.block.end_time.isoformat }}" index="{{ forloop.counter }}">
+    <day date="{{ page.block.start_time|localtime|date:"Y-m-d" }}" start="{{ page.block.start_time|localtime|date:"c" }}" end="{{ page.block.end_time|localtime|date:"c" }}" index="{{ forloop.counter }}">
       {% for venue in page.venues %}
         <room name="{{ venue.name }}">
           {% for row in page.rows %}
@@ -32,7 +34,7 @@
                   {# enough, but changes if the event is rescheduled. #}
                   {# Talks' guid will be stable across re-scheduling. #}
                   <event id="{{ items.item.pk }}" guid="{{ items.item.guid }}">
-                    <date>{{ row.start_time.isoformat }}</date>
+                    <date>{{ row.start_time|localtime|date:"c" }}</date>
                     <start>{{ row.start_time|time:"H:i" }}</start>
                     {% with dur=items.item.get_duration %}
                       <duration>{{ dur.hours|stringformat:"02d" }}:{{ dur.minutes|stringformat:"02d" }}</duration>
@@ -127,3 +129,4 @@
     </day>
   {% endfor %}
 </schedule>
+{% endlocaltime %}


### PR DESCRIPTION
When using a DB that doesn't store TZ information (like sqlite) we
were rendering the schedule in the system's local timezone, not the
conference's timezone.

This confuses some tools that ignore timezones (like sreview).