### PR TITLE
Don't completely override extra_head

### DIFF
--- a/wafer/templates/wafer/base_form.html
+++ b/wafer/templates/wafer/base_form.html
@@ -3,6 +3,7 @@
 {% load crispy_forms_tags %}
 {% load static %}
 {% block extra_head %}
+  {{ block.super }}
   {{ form.media.css }}
 {% endblock %}
 {% block content %}


### PR DESCRIPTION
The extra_head block in the base template may be used to add additional
theming bits and so on - Forms should inherit that, not completely
replace it.