### PR TITLE
Feature/drop django nose

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -74,7 +74,7 @@ jobs:
       env:
         TESTDB: postgres
       run: |
-        NOSE_WITH_COVERAGE=1 NOSE_COVER_PACKAGE=wafer python manage.py test
+        python manage.py test
 
   sqlite:
 
@@ -120,7 +120,7 @@ jobs:
     - name: Run Tests
       continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' || matrix.python-version == '3.10' }}
       run: |
-        NOSE_WITH_COVERAGE=1 NOSE_COVER_PACKAGE=wafer python manage.py test
+        python manage.py test
 
   translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,7 +22,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main'|| matrix.python-version == '3.10' }} )
+    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }} )
     strategy:
       max-parallel: 4
       matrix:
@@ -46,7 +46,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' || matrix.python-version == '3.10' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
@@ -70,7 +70,7 @@ jobs:
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'
     - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' || matrix.python-version == '3.10' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
       env:
         TESTDB: postgres
       run: |
@@ -80,7 +80,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main'|| matrix.python-version == '3.10' }} )
+    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main'}} )
     strategy:
       max-parallel: 4
       matrix:
@@ -104,7 +104,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' || matrix.python-version == '3.10' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
@@ -118,7 +118,7 @@ jobs:
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'
     - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' || matrix.python-version == '3.10' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
       run: |
         python -Wa manage.py test
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -75,7 +75,7 @@ jobs:
         TESTDB: postgres
       run: |
         export PYTHONWARNINGS=always
-        coverage run manage.py --source='wafer' test && coverage report --skip-covered
+        coverage run --source='wafer' manage.py test && coverage report --skip-covered
 
   sqlite:
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -74,7 +74,7 @@ jobs:
       env:
         TESTDB: postgres
       run: |
-        python manage.py test
+        python -Wa manage.py test
 
   sqlite:
 
@@ -120,7 +120,7 @@ jobs:
     - name: Run Tests
       continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' || matrix.python-version == '3.10' }}
       run: |
-        python manage.py test
+        python -Wa manage.py test
 
   translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -74,7 +74,8 @@ jobs:
       env:
         TESTDB: postgres
       run: |
-        python -Wa manage.py test
+        export PYTHONWARNINGS=always
+        coverage run manage.py --source='wafer' test && coverage report --skip-covered
 
   sqlite:
 
@@ -120,7 +121,8 @@ jobs:
     - name: Run Tests
       continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
       run: |
-        python -Wa manage.py test
+        export PYTHONWARNINGS=always
+        coverage run --source='wafer' manage.py test && coverage report --skip-covered
 
   translations:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ REQUIRES = [
     'django-bakery>=0.12.0',
     'django-crispy-forms',
     'django-markitup>=4.0.0',
-    'django-nose',
     'django-registration-redux',
     'django-reversion',
     'django-select2',

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -147,7 +147,6 @@ INSTALLED_APPS = (
     'reversion',
     'bakery',
     'crispy_forms',
-    'django_nose',
     'rest_framework',
     'django_select2',
     'wafer',
@@ -165,8 +164,6 @@ INSTALLED_APPS = (
     'registration',
     'django.contrib.admin',
 )
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to


### PR DESCRIPTION
Drop django-nose, since it's unmaintained and breaks on python 3.10

This also enables warnings when running the tests, so deprecations are easier to spot.