### PR TITLE
Replace crispy forms automatic form_tag with explict tags

### DIFF
--- a/wafer/talks/forms.py
+++ b/wafer/talks/forms.py
@@ -118,6 +118,7 @@ class TalkForm(forms.ModelForm):
         self.fields['authors'].label_from_instance = render_author
 
         self.helper = FormHelper(self)
+        self.helper.form_tag = False
         self.helper.include_media = False
         instance = kwargs['instance']
         submit_button = Submit('submit', _('Save') if instance else _('Submit'))

--- a/wafer/talks/templates/wafer.talks/talk_form.html
+++ b/wafer/talks/templates/wafer.talks/talk_form.html
@@ -40,7 +40,9 @@
         {% endblocktrans %}
       </div>
     {% endif %}
-    {% crispy form %}
+    <form method="post">
+      {% crispy form %}
+    </form>
   {% endif %}
 </section>
 {% endblock %}


### PR DESCRIPTION
It can be useful to extend the talk form with additional form content, either from additional apps or for client-side validated fields like a "I've have read the FAQ" checkbox. Crispy form's automatic tag makes that harder than it needs to be, and disabling it is the documented method for handling this use case.