### PR TITLE
template: allow overriding sponsors block

### DIFF
--- a/wafer/templates/wafer/base.html
+++ b/wafer/templates/wafer/base.html
@@ -35,7 +35,9 @@
       <h1>{{ WAFER_CONFERENCE_NAME }}</h1>
     {% endblock %}
   </div>
-  {% sponsors %}
+  {% block wafer_sponsors %}
+    {% sponsors %}
+  {% endblock %}
   {% block wafer_js %}
   <script src="{% static 'vendor/jquery/dist/jquery.min.js' %}"></script>
   <script src="{% static 'vendor/popper.js/dist/umd/popper.min.js' %}"></script>


### PR DESCRIPTION
In some conferences, it might be necessary to customize the markup
around the expansion of {% sponsors %}.