### PR TITLE
Add Django 4.1 to the test matrix

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,16 +22,20 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }} )
+    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == '4.1.0' || matrix.django-version == 'main' }} )
     strategy:
       max-parallel: 4
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2.0', '3.0.0', '3.1.0', '3.2.0', '4.0.0', 'main']
+        django-version: ['2.2.0', '3.0.0', '3.1.0', '3.2.0', '4.0.0', '4.1.0', 'main']
         exclude:
           - django-version: '4.0.0'
             python-version: '3.6'
           - django-version: '4.0.0'
+            python-version: '3.7'
+          - django-version: '4.1.0'
+            python-version: '3.6'
+          - django-version: '4.1.0'
             python-version: '3.7'
           - django-version: 'main'
             python-version: '3.6'
@@ -46,7 +50,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == '4.1.0' || matrix.django-version == 'main' }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
@@ -70,7 +74,7 @@ jobs:
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'
     - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == '4.1.0' || matrix.django-version == 'main' }}
       env:
         TESTDB: postgres
       run: |
@@ -81,16 +85,20 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main'}} )
+    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == '4.0.0' || matrix.django-version == '4.1.0' || matrix.django-version == 'main'}} )
     strategy:
       max-parallel: 4
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2.0', '3.0.0', '3.1.0', '3.2.0', '4.0.0', 'main']
+        django-version: ['2.2.0', '3.0.0', '3.1.0', '3.2.0', '4.0.0', '4.1.0', 'main']
         exclude:
           - django-version: '4.0.0'
             python-version: '3.6'
           - django-version: '4.0.0'
+            python-version: '3.7'
+          - django-version: '4.1.0'
+            python-version: '3.6'
+          - django-version: '4.1.0'
             python-version: '3.7'
           - django-version: 'main'
             python-version: '3.6'
@@ -105,7 +113,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == '4.1.0' || matrix.django-version == 'main' }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
@@ -119,7 +127,7 @@ jobs:
         pip install 'https://github.com/django/django/archive/main.tar.gz'
       if: matrix.django-version == 'main'
     - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == 'main' }}
+      continue-on-error: ${{ matrix.django-version == '4.0.0' || matrix.django-version == '4.1.0' || matrix.django-version == 'main' }}
       run: |
         export PYTHONWARNINGS=always
         coverage run --source='wafer' manage.py test && coverage report --skip-covered


### PR DESCRIPTION
Since Django 4.1 has been released, we should test against it for future sanity, even though our dependencies don't support it yet.