### PR TITLE
Feature/drop django timezone utc

### DIFF
--- a/wafer/schedule/migrations/0009_migrate_to_datetimes.py
+++ b/wafer/schedule/migrations/0009_migrate_to_datetimes.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import datetime
 
 from django.db import migrations
-from django.utils import timezone
 
 def convert_day_to_schedule_block(apps, schema_editor):
     """For each Day, create a schedule block with the
@@ -22,14 +21,14 @@ def convert_day_to_schedule_block(apps, schema_editor):
                                        day=day.date.day,
                                        hour=0,
                                        minute=0,
-                                       tzinfo=timezone.utc)
+                                       tzinfo=datetime.timezone.utc)
         end_time = datetime.datetime(year=day.date.year,
                                        month=day.date.month,
                                        day=day.date.day,
                                        hour=23,
                                        minute=59,
                                        second=59,
-                                       tzinfo=timezone.utc)
+                                       tzinfo=datetime.timezone.utc)
         block = ScheduleBlock.objects.create(start_time=start_time,
                                              end_time=end_time)
         block.save()
@@ -55,7 +54,7 @@ def convert_slot_time_to_date_time(apps, schema_editor):
                                                hour=slot.old_start_time.hour,
                                                minute=slot.old_start_time.minute,
                                                second=slot.old_start_time.second,
-                                               tzinfo=timezone.utc)
+                                               tzinfo=datetime.timezone.utc)
             slot.start_time = new_start_time
         new_end_time = datetime.datetime(year=day.date.year,
                                          month=day.date.month,
@@ -63,7 +62,7 @@ def convert_slot_time_to_date_time(apps, schema_editor):
                                          hour=slot.old_end_time.hour,
                                          minute=slot.old_end_time.minute,
                                          second=slot.old_end_time.second,
-                                         tzinfo=timezone.utc)
+                                         tzinfo=datetime.timezone.utc)
         slot.end_time = new_end_time
         slot.save()
 
@@ -80,7 +79,7 @@ def add_blocks_to_venues(apps, schema_editor):
                                            day=day.date.day,
                                            hour=0,
                                            minute=0,
-                                           tzinfo=timezone.utc)
+                                           tzinfo=datetime.timezone.utc)
             # Our earlier migration ensures this block exists
             block = ScheduleBlock.objects.filter(
                 start_time__exact=start_time).first()

--- a/wafer/schedule/tests/test_admin.py
+++ b/wafer/schedule/tests/test_admin.py
@@ -36,15 +36,15 @@ class SlotAdminTests(TestCase):
         timezone.activate('UTC')
         self.block = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 23, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.admin = SlotAdmin(Slot, None)
 
     def test_save_model_single_new(self):
         """Test save_model creating a new slot, but no additional slots"""
-        slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=timezone.utc))
+        slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=D.timezone.utc))
         # check that it's not saved in the database yet
         self.assertEqual(Slot.objects.count(), 0)
         request = HttpRequest()
@@ -52,13 +52,13 @@ class SlotAdminTests(TestCase):
         self.admin.save_model(request, slot, dummy, False)
         # check that it's now been saved in the database
         self.assertEqual(Slot.objects.count(), 1)
-        slot2 = Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)).get()
+        slot2 = Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)).get()
         self.assertEqual(slot, slot2)
 
     def test_save_model_change_slot(self):
         """Test save_model changing a slot"""
-        slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=timezone.utc))
+        slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=D.timezone.utc))
         # end_time is chosen as 12:30 so it stays valid through all the
         # subsequent fiddling
         slot.save()
@@ -66,35 +66,35 @@ class SlotAdminTests(TestCase):
         self.assertEqual(Slot.objects.count(), 1)
         request = HttpRequest()
         dummy = make_dummy_form(0)
-        slot.start_time = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        slot.start_time = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
         self.assertEqual(
-            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)).count(), 1)
+            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)).count(), 1)
         self.admin.save_model(request, slot, dummy, True)
         # Check that the database has changed
         self.assertEqual(
-            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)).count(), 0)
+            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)).count(), 0)
         self.assertEqual(Slot.objects.count(), 1)
-        slot2 = Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)).get()
+        slot2 = Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)).get()
         self.assertEqual(slot, slot2)
 
         # Check that setting additional has no influence on the change path
         dummy = make_dummy_form(3)
-        slot.start_time = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
+        slot.start_time = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
         self.assertEqual(
-            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)).count(), 0)
+            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)).count(), 0)
         self.admin.save_model(request, slot, dummy, True)
         # Still only 1 object
         self.assertEqual(Slot.objects.count(), 1)
         # And it has been updated
         self.assertEqual(
-            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)).count(), 0)
+            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)).count(), 0)
         self.assertEqual(
-            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)).count(), 1)
+            Slot.objects.filter(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)).count(), 1)
 
     def test_save_model_new_additional(self):
         """Test save_model changing a new slot with some additional slots"""
-        slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=timezone.utc))
+        slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=D.timezone.utc))
         # check that it's not saved in the database
         self.assertEqual(Slot.objects.count(), 0)
         request = HttpRequest()
@@ -105,49 +105,49 @@ class SlotAdminTests(TestCase):
         # check the hierachy is created correctly
         slot1 = Slot.objects.filter(previous_slot=slot).get()
         self.assertEqual(slot1.get_start_time(), slot.end_time)
-        self.assertEqual(slot1.end_time, D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot1.end_time, D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc))
         slot2 = Slot.objects.filter(previous_slot=slot1).get()
         self.assertEqual(slot2.get_start_time(), slot1.end_time)
-        self.assertEqual(slot2.end_time, D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot2.end_time, D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=D.timezone.utc))
         self.assertEqual(slot2.get_block(), slot.get_block())
         self.assertEqual(slot2.previous_slot, slot1)
         slot3 = Slot.objects.filter(previous_slot=slot2).get()
         self.assertEqual(slot3.get_start_time(), slot2.end_time)
-        self.assertEqual(slot3.end_time, D.datetime(2013, 9, 22, 13, 00, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot3.end_time, D.datetime(2013, 9, 22, 13, 00, 0, tzinfo=D.timezone.utc))
         self.assertEqual(slot3.get_block(), slot.get_block())
         self.assertEqual(slot3.previous_slot, slot2)
 
         # repeat checks with a different length of slot
         slot = Slot(previous_slot=slot3,
-                    end_time=D.datetime(2013, 9, 22, 14, 30, 0, tzinfo=timezone.utc))
+                    end_time=D.datetime(2013, 9, 22, 14, 30, 0, tzinfo=D.timezone.utc))
         dummy = make_dummy_form(4)
         self.admin.save_model(request, slot, dummy, False)
         self.assertEqual(Slot.objects.count(), 9)
         slot1 = Slot.objects.filter(previous_slot=slot).get()
         self.assertEqual(slot1.get_start_time(), slot.end_time)
-        self.assertEqual(slot1.end_time, D.datetime(2013, 9, 22, 16, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot1.end_time, D.datetime(2013, 9, 22, 16, 0, 0, tzinfo=D.timezone.utc))
         slot2 = Slot.objects.filter(previous_slot=slot1).get()
         self.assertEqual(slot2.get_start_time(), slot1.end_time)
-        self.assertEqual(slot2.end_time, D.datetime(2013, 9, 22, 17, 30, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot2.end_time, D.datetime(2013, 9, 22, 17, 30, 0, tzinfo=D.timezone.utc))
         self.assertEqual(slot2.get_block(), slot.get_block())
         self.assertEqual(slot2.previous_slot, slot1)
         slot3 = Slot.objects.filter(previous_slot=slot2).get()
         self.assertEqual(slot3.get_start_time(), slot2.end_time)
-        self.assertEqual(slot3.end_time, D.datetime(2013, 9, 22, 19, 00, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot3.end_time, D.datetime(2013, 9, 22, 19, 00, 0, tzinfo=D.timezone.utc))
         self.assertEqual(slot3.get_block(), slot.get_block())
         slot4 = Slot.objects.filter(previous_slot=slot3).get()
         self.assertEqual(slot4.get_start_time(), slot3.end_time)
-        self.assertEqual(slot4.end_time, D.datetime(2013, 9, 22, 20, 30, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot4.end_time, D.datetime(2013, 9, 22, 20, 30, 0, tzinfo=D.timezone.utc))
         self.assertEqual(slot4.get_block(), slot.get_block())
 
     def test_save_model_prev_slot_additional(self):
         """Test save_model changing a new slot with some additional slots,
            starting from a slot specified via previous slot"""
-        prev_slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                         end_time=D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=timezone.utc))
+        prev_slot = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                         end_time=D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=D.timezone.utc))
         prev_slot.save()
         self.assertEqual(Slot.objects.count(), 1)
-        slot = Slot(previous_slot=prev_slot, end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=timezone.utc))
+        slot = Slot(previous_slot=prev_slot, end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=D.timezone.utc))
         # Check that newly added slot isn't in the database
         self.assertEqual(Slot.objects.count(), 1)
         request = HttpRequest()
@@ -158,10 +158,10 @@ class SlotAdminTests(TestCase):
         # check the hierachy is created correctly
         slot1 = Slot.objects.filter(previous_slot=slot).get()
         self.assertEqual(slot1.get_start_time(), slot.end_time)
-        self.assertEqual(slot1.end_time, D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot1.end_time, D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=D.timezone.utc))
         slot2 = Slot.objects.filter(previous_slot=slot1).get()
         self.assertEqual(slot2.get_start_time(), slot1.end_time)
-        self.assertEqual(slot2.end_time, D.datetime(2013, 9, 22, 13, 00, 0, tzinfo=timezone.utc))
+        self.assertEqual(slot2.end_time, D.datetime(2013, 9, 22, 13, 00, 0, tzinfo=D.timezone.utc))
 
 
 class SlotListFilterTest(TestCase):
@@ -176,19 +176,19 @@ class SlotListFilterTest(TestCase):
         """Create some data for use in the actual tests."""
         self.block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 23, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.block3 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 24, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 24, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
 
         self.admin = SlotAdmin(Slot, None)
 
@@ -222,14 +222,14 @@ class SlotListFilterTest(TestCase):
     def test_time_filter_lookups(self):
         """Test that filter lookups are sane."""
         # Add some slots
-        slot1 = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                     end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=timezone.utc))
-        slot2 = Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=timezone.utc),
-                     end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=timezone.utc))
-        slot3 = Slot(start_time=D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc),
-                     end_time=D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc))
-        slot4 = Slot(start_time=D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc),
-                     end_time=D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc))
+        slot1 = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                     end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=D.timezone.utc))
+        slot2 = Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=D.timezone.utc),
+                     end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=D.timezone.utc))
+        slot3 = Slot(start_time=D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc),
+                     end_time=D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc))
+        slot4 = Slot(start_time=D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc),
+                     end_time=D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc))
         slot1.save()
         slot2.save()
         slot3.save()
@@ -246,21 +246,21 @@ class SlotListFilterTest(TestCase):
     def test_queryset_day_time(self):
         """Test queries with slots created purely by day + start_time"""
         slots = {}
-        slots[self.block1] = [Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                                   end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=timezone.utc))]
-        slots[self.block2] = [Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=timezone.utc),
-                                   end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=timezone.utc))]
+        slots[self.block1] = [Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                                   end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=D.timezone.utc))]
+        slots[self.block2] = [Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=D.timezone.utc),
+                                   end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=D.timezone.utc))]
 
         # ScheduleBlock1 slots
         for x in range(12, 17):
             slots[self.block1].append(Slot(
-                start_time=D.datetime(2013, 9, 22, x, 0, 0, tzinfo=timezone.utc),
-                end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=timezone.utc)))
+                start_time=D.datetime(2013, 9, 22, x, 0, 0, tzinfo=D.timezone.utc),
+                end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=D.timezone.utc)))
             if x < 15:
                 # Fewer slots for day 2
                 slots[self.block2].append(Slot(
-                    start_time=D.datetime(2013, 9, 23, x, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 23, x+1, 0, 0, tzinfo=timezone.utc)))
+                    start_time=D.datetime(2013, 9, 23, x, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 23, x+1, 0, 0, tzinfo=D.timezone.utc)))
         for d in slots:
             for s in slots[d]:
                 s.save()
@@ -298,25 +298,25 @@ class SlotListFilterTest(TestCase):
     def test_queryset_prev_slot(self):
         """Test lookup with a chain of previous slots."""
         slots = {}
-        prev = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=timezone.utc))
+        prev = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=D.timezone.utc))
         prev.save()
         slots[self.block1] = [prev]
-        prev = Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=timezone.utc))
+        prev = Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=D.timezone.utc))
         prev.save()
         slots[self.block2] = [prev]
         # ScheduleBlock1 slots
         for x in range(12, 17):
             prev1 = slots[self.block1][-1]
             slots[self.block1].append(Slot(previous_slot=prev1,
-                                           end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=timezone.utc)))
+                                           end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=D.timezone.utc)))
             slots[self.block1][-1].save()
             if x < 15:
                 prev2 = slots[self.block2][-1]
                 # Fewer slots for day 2
                 slots[self.block2].append(Slot(previous_slot=prev2,
-                                               end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=timezone.utc)))
+                                               end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=D.timezone.utc)))
                 slots[self.block2][-1].save()
         # Check Null filter
         TestFilter = self._make_block_filter(None)
@@ -352,12 +352,12 @@ class SlotListFilterTest(TestCase):
     def test_queryset_mixed(self):
         """Test with a mix of day+time and previous slot cases."""
         slots = {}
-        prev = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=timezone.utc))
+        prev = Slot(start_time=D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 22, 12, 00, 0, tzinfo=D.timezone.utc))
         prev.save()
         slots[self.block1] = [prev]
-        prev = Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=timezone.utc),
-                    end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=timezone.utc))
+        prev = Slot(start_time=D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=D.timezone.utc),
+                    end_time=D.datetime(2013, 9, 23, 12, 00, 0, tzinfo=D.timezone.utc))
         prev.save()
         slots[self.block2] = [prev]
         # ScheduleBlock1 slots
@@ -365,19 +365,19 @@ class SlotListFilterTest(TestCase):
             prev1 = slots[self.block1][-1]
             if x % 2:
                 slots[self.block1].append(Slot(previous_slot=prev1,
-                                               end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=timezone.utc)))
+                                               end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=D.timezone.utc)))
             else:
-                slots[self.block1].append(Slot(start_time=D.datetime(2013, 9, 22, x, 0, 0, tzinfo=timezone.utc),
-                                               end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=timezone.utc)))
+                slots[self.block1].append(Slot(start_time=D.datetime(2013, 9, 22, x, 0, 0, tzinfo=D.timezone.utc),
+                                               end_time=D.datetime(2013, 9, 22, x+1, 0, 0, tzinfo=D.timezone.utc)))
 
             slots[self.block1][-1].save()
             prev2 = slots[self.block2][-1]
             if x % 5:
                 slots[self.block2].append(Slot(previous_slot=prev2,
-                                               end_time=D.datetime(2013, 9, 23, x+1, 0, 0, tzinfo=timezone.utc)))
+                                               end_time=D.datetime(2013, 9, 23, x+1, 0, 0, tzinfo=D.timezone.utc)))
             else:
-                slots[self.block2].append(Slot(start_time=D.datetime(2013, 9, 23, x, 0, 0, tzinfo=timezone.utc),
-                                               end_time=D.datetime(2013, 9, 23, x+1, 0, 0, tzinfo=timezone.utc)))
+                slots[self.block2].append(Slot(start_time=D.datetime(2013, 9, 23, x, 0, 0, tzinfo=D.timezone.utc),
+                                               end_time=D.datetime(2013, 9, 23, x+1, 0, 0, tzinfo=D.timezone.utc)))
             slots[self.block2][-1].save()
         # Check Null filter
         TestFilter = self._make_block_filter(None)
@@ -404,17 +404,17 @@ class ValidationTests(TestCase):
         """Test that we can detect clashes correctly"""
         day1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(day1)
         venue2.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start2, end_time=end)
@@ -472,15 +472,15 @@ class ValidationTests(TestCase):
         # Create a item with both a talk and a page assigned
         day1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
@@ -545,16 +545,16 @@ class ValidationTests(TestCase):
         # Create a item with a gap in the slots assigned to it
         day1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start2, end_time=start3)
@@ -595,17 +595,17 @@ class ValidationTests(TestCase):
         # 11-12 Talk 1   Page 1
         day1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(day1)
         venue2.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
@@ -649,21 +649,21 @@ class ValidationTests(TestCase):
            correctly."""
         day1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         day2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 23, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(day1)
         venue2.blocks.add(day2)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
 
@@ -683,8 +683,8 @@ class ValidationTests(TestCase):
         assert venues[0][0] == venue2
         assert set(venues[0][1]) == set([item2])
 
-        start1d2 = D.datetime(2013, 9, 23, 10, 0, 0, tzinfo=timezone.utc)
-        start2d2 = D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=timezone.utc)
+        start1d2 = D.datetime(2013, 9, 23, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2d2 = D.datetime(2013, 9, 23, 11, 0, 0, tzinfo=D.timezone.utc)
         slot2 = Slot.objects.create(start_time=start1d2, end_time=start2d2)
         item3 = ScheduleItem.objects.create(venue=venue2, page_id=page.pk)
 
@@ -720,16 +720,16 @@ class ValidationTests(TestCase):
            case for it."""
         day1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
         page = Page.objects.create(name="test page", slug="test")
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start2, end_time=end)

--- a/wafer/schedule/tests/test_models.py
+++ b/wafer/schedule/tests/test_models.py
@@ -19,14 +19,14 @@ class BlockTests(TestCase):
         """Create some days and check the results."""
         o1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         o2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 23, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
 
         self.assertEqual(ScheduleBlock.objects.count(), 2)
 
@@ -42,14 +42,14 @@ class BlockTests(TestCase):
         """Create 2 blocks that each cross midnight and check the results."""
         ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 3, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 23, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 24, 3, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
 
         self.assertEqual(ScheduleBlock.objects.count(), 2)
 
@@ -62,82 +62,82 @@ class BlockTests(TestCase):
         """Test our blocks have start_time < end_time."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 11, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block1.clean)
         # Test across midnight
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 23, 1, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 23, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block2.clean)
 
     def test_changing_block(self):
         """Test that we can update block info and have correct validation behavior."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 27, 11, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 27, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         block1.clean()
         block1.save()
         # These should work
         block1.start_time = D.datetime(2013, 9, 27, 9, 0, 0,
-                                       tzinfo=timezone.utc)
+                                       tzinfo=D.timezone.utc)
         block1.clean()
         block1.save()
         block1.end_time = D.datetime(2013, 9, 27, 12, 0, 0,
-                                     tzinfo=timezone.utc)
+                                     tzinfo=D.timezone.utc)
         block1.clean()
         block1.save()
         # This should fail
         block1.start_time = D.datetime(2013, 9, 27, 15, 0, 0,
-                                       tzinfo=timezone.utc)
+                                       tzinfo=D.timezone.utc)
         self.assertRaises(ValidationError, block1.clean)
 
     def test_block_overlaps(self):
         """Test that we can't create overlapping blocks."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 1, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         # Test starting in the block
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 11, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 23, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block2.clean)
         # Test ending in the block
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 0, 30, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 11, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block2.clean)
         # Test across midnight
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 11, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 23, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block2.clean)
         # Test included block
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 3, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 4, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block2.clean)
         # Test surrounding block
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 0, 15, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 4, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, block2.clean)
 
 
@@ -147,25 +147,25 @@ class SlotTests(TestCase):
         """Test we can assign slots to a Block that spans only few hours."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         slot1 = Slot(start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 22, 10, 20, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertEqual(slot1.get_block(), block1)
         self.assertEqual(slot1.get_duration(), {'hours': 1,
                                                 'minutes': 20})
         # Check end and start times
         slot2 = Slot(start_time=D.datetime(2013, 9, 22, 12, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 22, 13, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot3 = Slot(start_time=D.datetime(2013, 9, 22, 18, 30, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertEqual(slot2.get_block(), block1)
         self.assertEqual(slot2.get_duration(), {'hours': 1,
                                                 'minutes': 0})
@@ -179,13 +179,13 @@ class SlotTests(TestCase):
            that spans midnight."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 23, 8, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         slot1 = Slot(start_time=D.datetime(2013, 9, 22, 23, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 23, 1, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertEqual(slot1.get_block(), block1)
         self.assertEqual(slot1.get_duration(), {'hours': 2,
                                                 'minutes': 0})
@@ -195,27 +195,27 @@ class SlotTests(TestCase):
         """Test that we can update slots and get the correct validation behaviour."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 26, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 26, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         slot1 = Slot(start_time=D.datetime(2013, 9, 26, 10, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 12, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot1.clean()
         slot1.save()
         # This should work
         slot1.start_time = D.datetime(2013, 9, 26, 9, 0, 0,
-                                      tzinfo=timezone.utc)
+                                      tzinfo=D.timezone.utc)
         slot1.clean()
         slot1.save()
         slot1.end_time = D.datetime(2013, 9, 26, 11, 0, 0,
-                                    tzinfo=timezone.utc)
+                                    tzinfo=D.timezone.utc)
         slot1.clean()
         slot1.save()
         # This should fail
         slot1.start_time = D.datetime(2013, 9, 26, 12, 0, 0,
-                                      tzinfo=timezone.utc)
+                                      tzinfo=D.timezone.utc)
         self.assertRaises(ValidationError, slot1.clean)
         slot1.delete()
         block1.delete()
@@ -224,58 +224,58 @@ class SlotTests(TestCase):
         """Test that we can't create overlapping slots."""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 26, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 26, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         slot1 = Slot(start_time=D.datetime(2013, 9, 26, 10, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 12, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot1.clean()
         slot1.save()
         # Start time is in the middle of slot1
         slot2 = Slot(start_time=D.datetime(2013, 9, 26, 11, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 13, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
         # End time is in the middle of slot2
         slot2 = Slot(start_time=D.datetime(2013, 9, 26, 9, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 11, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
         # Slot 2 totally encloses slot 1
         slot2 = Slot(start_time=D.datetime(2013, 9, 26, 9, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 13, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
         # Slot 2 totally included in slot 1
         slot2 = Slot(start_time=D.datetime(2013, 9, 26, 11, 30, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 12, 30, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
         # Slot 2 has the same times as slot 1
         slot2 = Slot(start_time=D.datetime(2013, 9, 26, 11, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 13, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
         # Check we don't raise errors on slots that touch as intended
         # slot 1 start time is slot 2's end time
         slot2 = Slot(start_time=D.datetime(2013, 9, 26, 9, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 10, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot2.clean()
         slot2.save()
         # slot 1 end time is slot 2's start time
         slot3 = Slot(start_time=D.datetime(2013, 9, 26, 12, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 13, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot3.clean()
 
         slot1.delete()
@@ -288,32 +288,32 @@ class SlotTests(TestCase):
 
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 26, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 26, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         slot1 = Slot(start_time=D.datetime(2013, 9, 26, 10, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 26, 12, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot1.clean()
         slot1.save()
         slot2 = Slot(previous_slot=slot1,
                      end_time=D.datetime(2013, 9, 26, 13, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         slot2.clean()
         slot2.save()
 
         # Check that updating slot1's end_time to 12:30 works as expected
-        slot1.end_time = D.datetime(2013, 9, 26, 12, 30, 0, tzinfo=timezone.utc)
+        slot1.end_time = D.datetime(2013, 9, 26, 12, 30, 0, tzinfo=D.timezone.utc)
         slot1.clean()
         slot1.save()
 
         self.assertEqual(slot2.get_start_time(),
                          D.datetime(2013, 9, 26, 12, 30, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
 
         # Check that updating slot1's end_time to 13:30 fails, though
-        slot1.end_time = D.datetime(2013, 9, 26, 13, 30, 0, tzinfo=timezone.utc)
+        slot1.end_time = D.datetime(2013, 9, 26, 13, 30, 0, tzinfo=D.timezone.utc)
         self.assertRaises(ValidationError, slot1.clean)
 
     def test_invalid_slot(self):
@@ -321,24 +321,24 @@ class SlotTests(TestCase):
         # Same day
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         slot1 = Slot(start_time=D.datetime(2013, 9, 22, 11, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 22, 10, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot1.clean)
         block2 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 24, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 25, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         # Different day,
         slot2 = Slot(start_time=D.datetime(2013, 9, 25, 1, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 24, 3, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
 
         block1.delete()
@@ -348,32 +348,32 @@ class SlotTests(TestCase):
         """Test that we can't create a slot outside the block's times"""
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 18, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         # Totally after
         slot1 = Slot(start_time=D.datetime(2013, 9, 22, 23, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 23, 1, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot1.clean)
         # Totally before
         slot2 = Slot(start_time=D.datetime(2013, 9, 21, 23, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 21, 1, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot2.clean)
         # Overlaps the end
         slot3 = Slot(start_time=D.datetime(2013, 9, 22, 17, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot3.clean)
         # Overlaps the start
         slot4 = Slot(start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                           tzinfo=timezone.utc),
+                                           tzinfo=D.timezone.utc),
                      end_time=D.datetime(2013, 9, 22, 10, 0, 0,
-                                         tzinfo=timezone.utc))
+                                         tzinfo=D.timezone.utc))
         self.assertRaises(ValidationError, slot4.clean)
 
 
@@ -384,24 +384,24 @@ class LastUpdateTests(TestCase):
         timezone.activate('UTC')
         block1 = ScheduleBlock.objects.create(
                 start_time=D.datetime(2013, 9, 22, 9, 0, 0,
-                                      tzinfo=timezone.utc),
+                                      tzinfo=D.timezone.utc),
                 end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                    tzinfo=timezone.utc))
+                                    tzinfo=D.timezone.utc))
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(block1)
         venue2.blocks.add(block1)
 
         start1 = D.datetime(2013, 9, 22, 10, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         start2 = D.datetime(2013, 9, 22, 11, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         start3 = D.datetime(2013, 9, 22, 12, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         start4 = D.datetime(2013, 9, 22, 13, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         start5 = D.datetime(2013, 9, 22, 14, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         self.slots = []
         self.slots.append(Slot.objects.create(start_time=start1,
                                               end_time=start2))

--- a/wafer/schedule/tests/test_views.py
+++ b/wafer/schedule/tests/test_views.py
@@ -50,13 +50,13 @@ def make_slot():
     """ Make a slot. """
     day = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
     start = D.datetime(2013, 9, 22, 10, 0, 0,
-                       tzinfo=timezone.utc)
-    end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=timezone.utc)
+                       tzinfo=D.timezone.utc)
+    end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=D.timezone.utc)
     slot = Slot.objects.create(start_time=start, end_time=end)
     return slot
 
@@ -86,9 +86,9 @@ class ScheduleViewTests(TestCase):
         # 12-13   Item3       Item6
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
 
         venue1 = Venue.objects.create(order=1, name='Venue 1')
@@ -97,13 +97,13 @@ class ScheduleViewTests(TestCase):
         venue2.blocks.add(day1)
 
         start1 = D.datetime(2013, 9, 22, 10, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         start2 = D.datetime(2013, 9, 22, 11, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         start3 = D.datetime(2013, 9, 22, 12, 0, 0,
-                            tzinfo=timezone.utc)
+                            tzinfo=D.timezone.utc)
         end = D.datetime(2013, 9, 22, 13, 0, 0,
-                         tzinfo=timezone.utc)
+                         tzinfo=D.timezone.utc)
 
         pages = make_pages(6)
         venues = [venue1, venue1, venue1, venue2, venue2, venue2]
@@ -167,19 +167,19 @@ class ScheduleViewTests(TestCase):
         # 12-13   Item1       Item4
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue2.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
 
         pages = make_pages(6)
         venues = [venue1, venue1, venue1, venue2, venue2, venue2]
@@ -246,15 +246,15 @@ class ScheduleViewTests(TestCase):
         # 12-13   Item3       Item6
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         day2 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 23, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
@@ -263,12 +263,12 @@ class ScheduleViewTests(TestCase):
         venue2.blocks.add(day1)
         venue2.blocks.add(day2)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
-        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=timezone.utc)
-        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=timezone.utc)
+        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=D.timezone.utc)
+        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=D.timezone.utc)
 
         pages = make_pages(6)
         venues = [venue1, venue1, venue1, venue2, venue2, venue2]
@@ -319,15 +319,15 @@ class ScheduleViewTests(TestCase):
         # This is the same schedule as test_multiple_days
         block1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         block2 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 23, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(block1)
@@ -336,12 +336,12 @@ class ScheduleViewTests(TestCase):
         venue2.blocks.add(block1)
         venue2.blocks.add(block2)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
-        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=timezone.utc)
-        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=timezone.utc)
+        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=D.timezone.utc)
+        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=D.timezone.utc)
 
         pages = make_pages(6)
         venues = [venue1, venue1, venue1, venue2, venue2, venue2]
@@ -431,27 +431,27 @@ class ScheduleViewTests(TestCase):
         # 12-13   Item3
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         day2 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 23, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue2.blocks.add(day2)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
-        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=timezone.utc)
-        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=timezone.utc)
+        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=D.timezone.utc)
+        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=D.timezone.utc)
 
         pages = make_pages(3)
         venues = [venue1, venue1, venue2]
@@ -505,9 +505,9 @@ class ScheduleViewTests(TestCase):
         # 14-15   Item3 +     Item5     --
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
@@ -516,12 +516,12 @@ class ScheduleViewTests(TestCase):
         venue2.blocks.add(day1)
         venue3.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=D.timezone.utc)
 
         # We create the slots out of order to tt
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
@@ -628,21 +628,21 @@ class ScheduleViewTests(TestCase):
         # 14-15   Item4         |
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(day1)
         venue2.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start2, end_time=start3)
@@ -722,9 +722,9 @@ class ScheduleViewTests(TestCase):
         # 14-15   Item3 +     Item4+     --
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
@@ -733,12 +733,12 @@ class ScheduleViewTests(TestCase):
         venue2.blocks.add(day1)
         venue3.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=D.timezone.utc)
 
         # We create the slots out of order to tt
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
@@ -823,14 +823,14 @@ class ScheduleViewTests(TestCase):
         """Test that the highlight-venue option works"""
         # This is the same schedule as test_multiple_days
         day1 = ScheduleBlock.objects.create(start_time=D.datetime(2013, 9, 22, 1, 0, 0,
-                                                                  tzinfo=timezone.utc),
+                                                                  tzinfo=D.timezone.utc),
                                             end_time=D.datetime(2013, 9, 22, 23, 0, 0,
-                                                                tzinfo=timezone.utc),
+                                                                tzinfo=D.timezone.utc),
                                             )
         day2 = ScheduleBlock.objects.create(start_time=D.datetime(2013, 9, 23, 1, 0, 0,
-                                                                  tzinfo=timezone.utc),
+                                                                  tzinfo=D.timezone.utc),
                                             end_time=D.datetime(2013, 9, 23, 23, 0, 0,
-                                                                tzinfo=timezone.utc),
+                                                                tzinfo=D.timezone.utc),
                                             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
@@ -839,12 +839,12 @@ class ScheduleViewTests(TestCase):
         venue2.blocks.add(day1)
         venue2.blocks.add(day2)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end1 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
 
-        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=timezone.utc)
-        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=timezone.utc)
+        start3 = D.datetime(2013, 9, 23, 12, 0, 0, tzinfo=D.timezone.utc)
+        end2 = D.datetime(2013, 9, 23, 13, 0, 0, tzinfo=D.timezone.utc)
 
         pages = make_pages(6)
         venues = [venue1, venue1, venue1, venue2, venue2, venue2]
@@ -1001,36 +1001,36 @@ class CurrentViewTests(TestCase):
         """Create a schedule and check that the current view looks sane."""
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         day2 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 23, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(day1)
         venue2.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
 
         # During the first slot
-        cur1 = D.datetime(2013, 9, 22, 10, 30, 0, tzinfo=timezone.utc)
+        cur1 = D.datetime(2013, 9, 22, 10, 30, 0, tzinfo=D.timezone.utc)
         # Middle of the day
-        cur2 = D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=timezone.utc)
-        cur3 = D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=timezone.utc)
+        cur2 = D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=D.timezone.utc)
+        cur3 = D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=D.timezone.utc)
         # During the last slot
-        cur4 = D.datetime(2013, 9, 22, 13, 30, 0, tzinfo=timezone.utc)
+        cur4 = D.datetime(2013, 9, 22, 13, 30, 0, tzinfo=D.timezone.utc)
         # After the last slot
-        cur5 = D.datetime(2013, 9, 22, 15, 30, 0, tzinfo=timezone.utc)
+        cur5 = D.datetime(2013, 9, 22, 15, 30, 0, tzinfo=D.timezone.utc)
 
         slots = []
 
@@ -1111,9 +1111,9 @@ class CurrentViewTests(TestCase):
         # 14-15   --          Item9     Item10
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
@@ -1122,12 +1122,12 @@ class CurrentViewTests(TestCase):
         venue2.blocks.add(day1)
         venue3.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start2, end_time=start3)
@@ -1155,12 +1155,12 @@ class CurrentViewTests(TestCase):
         items[9].slots.add(slot5)
 
         # During the first slot
-        cur1 = D.datetime(2013, 9, 22, 10, 30, 0, tzinfo=timezone.utc)
+        cur1 = D.datetime(2013, 9, 22, 10, 30, 0, tzinfo=D.timezone.utc)
         # Middle of the day
-        cur2 = D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=timezone.utc)
-        cur3 = D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=timezone.utc)
+        cur2 = D.datetime(2013, 9, 22, 11, 30, 0, tzinfo=D.timezone.utc)
+        cur3 = D.datetime(2013, 9, 22, 12, 30, 0, tzinfo=D.timezone.utc)
         # During the last slot
-        cur4 = D.datetime(2013, 9, 22, 14, 30, 0, tzinfo=timezone.utc)
+        cur4 = D.datetime(2013, 9, 22, 14, 30, 0, tzinfo=D.timezone.utc)
 
         c = Client()
         response = c.get('/schedule/current/', {'timestamp': cur1.isoformat()})
@@ -1209,9 +1209,9 @@ class CurrentViewTests(TestCase):
     def test_current_view_highlight_venue(self):
         """Test that the current view highlight's stuff correctly"""
         day1 = ScheduleBlock.objects.create(start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                                                  tzinfo=timezone.utc),
+                                                                  tzinfo=D.timezone.utc),
                                             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                                                tzinfo=timezone.utc),
+                                                                tzinfo=D.timezone.utc),
                                             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
@@ -1220,12 +1220,12 @@ class CurrentViewTests(TestCase):
         venue2.blocks.add(day1)
         venue3.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 15, 0, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start2, end_time=start3)
@@ -1387,16 +1387,16 @@ class CurrentViewTests(TestCase):
         """Test that invalid schedules return a inactive current view."""
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(day1)
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        cur1 = D.datetime(2013, 9, 22, 10, 30, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        end = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        cur1 = D.datetime(2013, 9, 22, 10, 30, 0, tzinfo=D.timezone.utc)
 
         slot1 = Slot.objects.create(start_time=start1, end_time=start2)
         slot2 = Slot.objects.create(start_time=start1, end_time=end)
@@ -1423,15 +1423,15 @@ class NonHTMLViewTests(TestCase):
         timezone.activate('UTC')
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         day2 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 23, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
@@ -1439,13 +1439,13 @@ class NonHTMLViewTests(TestCase):
         venue2.blocks.add(day1)
         venue1.blocks.add(day2)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
-        start6 = D.datetime(2013, 9, 23, 14, 0, 0, tzinfo=timezone.utc)
-        end6 = D.datetime(2013, 9, 23, 15, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
+        start6 = D.datetime(2013, 9, 23, 14, 0, 0, tzinfo=D.timezone.utc)
+        end6 = D.datetime(2013, 9, 23, 15, 0, 0, tzinfo=D.timezone.utc)
 
         slots = []
 
@@ -1524,7 +1524,7 @@ class NonHTMLViewTests(TestCase):
         # Check we have the right time in places
         event = calendar.walk(name='VEVENT')[0]
         self.assertEqual(event['dtstart'].params['value'], 'DATE-TIME')
-        self.assertEqual(event['dtstart'].dt, D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(event['dtstart'].dt, D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc))
         # Check that we have the page slug in the ical event
         self.assertTrue('/test0/' in event['url'])
 
@@ -1561,26 +1561,26 @@ class JsonViewTests(TestCase):
         timezone.activate('UTC')
         day1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         day2 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 23, 7, 0, 0,
-                                  tzinfo=timezone.utc),
+                                  tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 23, 19, 0, 0,
-                                tzinfo=timezone.utc),
+                                tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue2 = Venue.objects.create(order=2, name='Venue 2')
         venue1.blocks.add(day1)
         venue2.blocks.add(day1)
 
-        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=timezone.utc)
-        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=timezone.utc)
-        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
-        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=timezone.utc)
-        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
+        start1 = D.datetime(2013, 9, 22, 10, 0, 0, tzinfo=D.timezone.utc)
+        start2 = D.datetime(2013, 9, 22, 11, 0, 0, tzinfo=D.timezone.utc)
+        start3 = D.datetime(2013, 9, 22, 12, 0, 0, tzinfo=D.timezone.utc)
+        start4 = D.datetime(2013, 9, 22, 13, 0, 0, tzinfo=D.timezone.utc)
+        start5 = D.datetime(2013, 9, 22, 14, 0, 0, tzinfo=D.timezone.utc)
 
         slots = []
 

--- a/wafer/talks/tests/test_wafer_basic_talks.py
+++ b/wafer/talks/tests/test_wafer_basic_talks.py
@@ -1,7 +1,9 @@
 # This tests the very basic talk stuff, to ensure some levels of sanity
 
+from datetime import timezone
+
 from django.contrib.auth import get_user_model
-from django.utils.timezone import datetime, now, utc
+from django.utils.timezone import datetime, now
 
 from django.test import TestCase
 
@@ -83,8 +85,8 @@ class TestBasicTalks(TestCase):
 
 
     def test_is_late_submission_not_late(self):
-        deadline = datetime(2019, 11, 1, 0, 0, 0, 0, utc)
-        before_deadline = datetime(2019, 10, 15, 0, 0, 0, 0, utc)
+        deadline = datetime(2019, 11, 1, 0, 0, 0, 0, timezone.utc)
+        before_deadline = datetime(2019, 10, 15, 0, 0, 0, 0, timezone.utc)
 
         talk_type = TalkType(submission_deadline=deadline)
         not_late = Talk(talk_type=talk_type, submission_time=before_deadline)
@@ -92,8 +94,8 @@ class TestBasicTalks(TestCase):
 
 
     def test_is_late_submission_late(self):
-        deadline = datetime(2019, 11, 1, 0, 0, 0, 0, utc)
-        after_deadline = datetime(2019, 11, 2, 0, 0, 0, 0, utc)
+        deadline = datetime(2019, 11, 1, 0, 0, 0, 0, timezone.utc)
+        after_deadline = datetime(2019, 11, 2, 0, 0, 0, 0, timezone.utc)
 
         talk_type = TalkType(submission_deadline=deadline)
         late = Talk(talk_type=talk_type, submission_time=after_deadline)


### PR DESCRIPTION
This silences the massive flood of warnings seen when running the tests with Django 4.1 .