### PR TITLE
Add DEFAULT_AUTO_FIELD setting to silence complaints from Django 3.2 onwards

### DIFF
--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -333,3 +333,6 @@ BAKERY_VIEWS = (
 
 # Groups to which new users should be automatically added.
 WAFER_DEFAULT_GROUPS = ()
+
+# Specify DEFAULT_AUTO_FIELD to make Django >= 3.2 happy
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
This has no effect on earlier Django versions, so seems safe enough.