### PR TITLE
Add fields to the user list to allow sorting by last login or date joined

### DIFF
--- a/wafer/users/admin.py
+++ b/wafer/users/admin.py
@@ -44,6 +44,11 @@ class UserProfileInline(admin.StackedInline):
 class UserAdmin(UserAdmin):
     inlines = (UserProfileInline,)
 
+    # We add date_joined and last login to the list view, as these can be
+    # useful for checking for spam accounts
+    list_display = ("username", "email", "first_name", "last_name",
+                    "date_joined", "last_login", "is_staff")
+
     def autocomplete_view(self, request):
         """Replace the autocomplete view for the users search widget"""
         return AuthorAutocompleteView.as_view(model_admin=self)(request)


### PR DESCRIPTION
Looking for possible spam registrations usually focuses on recent registrations. Being able to sort the user list by date joined or last login simplifies this significantly.