### PR TITLE
Improve the 'no talks submitted' display for talks and speakers

### DIFF
--- a/wafer/talks/templates/wafer.talks/speakers.html
+++ b/wafer/talks/templates/wafer.talks/speakers.html
@@ -33,6 +33,17 @@
         </div>
       {% endfor %}
     </div>
+  {% empty %}
+    <!-- We show an empty entry wo a) there's some content here and
+                                   b) it's easier to check some of the styling -->
+    <h1>{% trans 'Speakers' %}</h1>
+    <div class="container speakers-list">
+        <div class="row">
+           <div class="wafer-speakers-name">
+              <p>No accepted talks yet</p>
+           </div>
+        </div>
+    </div>
   {% endfor %}
 </section>
 {% endblock %}

--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -56,10 +56,19 @@
           </tr>
         {% endfor %}
       {% empty %}
+        <thead class='thead-dark'>
+          <tr>
+            <th>
+              {% trans "Talk" %}
+            </th>
+            {% if languages %}<th>{% trans "Language" %}</th>{% endif %}
+            <th>{% trans "Speakers" %}</th>
+          </tr>
+        </thead>
         <tr>
-          <th colspan="{% if languages %}3{% else %}2{% endif %}">
+          <td colspan="{% if languages %}3{% else %}2{% endif %}">
             {% trans 'No talks accepted yet.' %}
-          </th>
+          </td>
         </tr>
       {% endfor %}
     </table>


### PR DESCRIPTION
The current 'No talks accepted' pages are missing bits or blank - this adds a bit more theming so they hopefully look less ugly.