### PR TITLE
Feature/add ticket types to profile

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -140,6 +140,12 @@ Wafer's settings
     It should return a boolean result.
     The default function checks for a Quicket ticket.
 
+``WAFER_USER_TICKET_TYPES``
+   A function which returns a list of ticket types associated with a user.
+   This is intende to help track remote vs in-person tickets and similar cases.
+   It should return a list of ticket type descriptions.
+   The default function returns the types of any Quicket tickets associated with the user.
+
 ``WAFER_VIDEO``
     A boolean flag.
     When ``True``, the default talk submission form will ask for a video

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -291,6 +291,9 @@ WAFER_REGISTRATION_OPEN = True
 WAFER_REGISTRATION_MODE = 'ticket'
 # WAFER_USER_IS_REGISTERED should return a boolean, when passed a Django user.
 WAFER_USER_IS_REGISTERED = 'wafer.tickets.models.user_is_registered'
+# If using 'ticket' registration, WAFER_USER_TICKET_TYPES should return
+# the ticket types associated with the user as a list
+WAFER_USER_TICKET_TYPES = 'wafer.tickets.models.get_user_ticket_types'
 
 # Allow registered and anonymous users to see registered users
 WAFER_PUBLIC_ATTENDEE_LIST = True

--- a/wafer/tickets/models.py
+++ b/wafer/tickets/models.py
@@ -25,4 +25,11 @@ class Ticket(models.Model):
 
 
 def user_is_registered(user):
+    """This function assumes that all ticket types are equally valid for
+       determining the registration status"""
     return Ticket.objects.filter(user=user).exists()
+
+
+def get_user_ticket_types(user):
+    """This returns the distinct ticket types associaated with a user"""
+    return set([x.type for x in Ticket.objects.filter(user=user)])

--- a/wafer/tickets/tests/test_helpers.py
+++ b/wafer/tickets/tests/test_helpers.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from wafer.tests.utils import create_user
+from wafer.tickets.views import import_ticket
+from wafer.tickets.models import Ticket, TicketType, user_is_registered, get_user_ticket_types
+
+
+class TicketsHelperFunctionTests(TestCase):
+    """Test the helper functions"""
+
+    def setUp(self):
+        self.user_email = "user2@example.com"
+        self.user = create_user("User Foo 2", email=self.user_email)
+
+    def test_user_is_registered(self):
+        self.assertFalse(user_is_registered(self.user))
+        import_ticket(77777, "Individual", self.user_email)
+        # Check the we are now registered
+        self.assertTrue(user_is_registered(self.user))
+
+    def test_get_user_ticket_types(self):
+        import_ticket(77777, "Individual", self.user_email)
+        ticket_type = TicketType.objects.get(name="Individual")
+        self.assertEqual(get_user_ticket_types(self.user), set([ticket_type]))
+        # Buy a second ticket with a different type
+        import_ticket(888888, "Corp", self.user_email)
+        type2 =  TicketType.objects.get(name="Corp")
+        self.assertEqual(get_user_ticket_types(self.user), set([ticket_type, type2]))
+

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -98,6 +98,10 @@ class UserProfile(models.Model):
         is_registered = import_string(settings.WAFER_USER_IS_REGISTERED)
         return is_registered(self.user)
 
+    def ticket_types(self):
+        ticket_types = import_string(settings.WAFER_USER_TICKET_TYPES)
+        return ticket_types(self.user)
+
     is_registered.boolean = True
 
 

--- a/wafer/users/models.py
+++ b/wafer/users/models.py
@@ -100,7 +100,7 @@ class UserProfile(models.Model):
 
     def ticket_types(self):
         ticket_types = import_string(settings.WAFER_USER_TICKET_TYPES)
-        return ticket_types(self.user)
+        return [x.name for x in ticket_types(self.user)]
 
     is_registered.boolean = True
 

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -102,6 +102,9 @@
                {% endif %}
              </div>
            {% endif %}
+           {% if WAFER_REGISTRATION_MODE == 'ticket' and profile.is_registered  %}
+              {{ profile.tickets }}
+           {% endif %}
         {% endblock speaker_registered %}
       {% endif %}
     {% endif %}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -26,26 +26,28 @@
         {% endif %}
       </div>
       <div class="col-md-10">
-        {% if can_edit %}
-          <ul class="float-end btn-group btn-group-vertical profile-links">
-            <li><a href="{% url 'wafer_user_edit' object.username %}" class="btn btn-secondary">{% trans 'Edit Account' %}</a></li>
-            <li><a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn btn-secondary">{% trans 'Edit Profile' %}</a></li>
-            {% if WAFER_REGISTRATION_OPEN %}
-              {% if WAFER_REGISTRATION_MODE == 'ticket' and not profile.is_registered  %}
-                {% url 'wafer_ticket_claim' as register_url %}
-              {% endif %}
-              {% if WAFER_REGISTRATION_MODE == 'custom' %}
-                {% url 'register' as register_url %}
-              {% endif %}
-              {% if register_url %}
-                <li><a href="{{ register_url }}" class="btn btn-secondary">{% if profile.is_registered %}{% trans 'Update registration' context "conference" %}{% else %}{% trans 'Register' context "conference" %}{% endif %}</a></li>
-              {% endif %}
-            {% endif %}
-            {% if WAFER_TALKS_OPEN %}
-              <li><a href="{% url 'wafer_talk_submit' %}" class="btn btn-secondary">{% trans 'Submit Talk Proposal' %}</a></li>
-            {% endif %}
-          </ul>
-        {% endif %}
+        {% block side_menu %}
+           {% if can_edit %}
+             <ul class="float-end btn-group btn-group-vertical profile-links">
+               <li><a href="{% url 'wafer_user_edit' object.username %}" class="btn btn-secondary">{% trans 'Edit Account' %}</a></li>
+               <li><a href="{% url 'wafer_user_edit_profile' object.username %}" class="btn btn-secondary">{% trans 'Edit Profile' %}</a></li>
+               {% if WAFER_REGISTRATION_OPEN %}
+                 {% if WAFER_REGISTRATION_MODE == 'ticket' and not profile.is_registered  %}
+                   {% url 'wafer_ticket_claim' as register_url %}
+                 {% endif %}
+                 {% if WAFER_REGISTRATION_MODE == 'custom' %}
+                   {% url 'register' as register_url %}
+                 {% endif %}
+                 {% if register_url %}
+                   <li><a href="{{ register_url }}" class="btn btn-secondary">{% if profile.is_registered %}{% trans 'Update registration' context "conference" %}{% else %}{% trans 'Register' context "conference" %}{% endif %}</a></li>
+                 {% endif %}
+               {% endif %}
+               {% if WAFER_TALKS_OPEN %}
+                 <li><a href="{% url 'wafer_talk_submit' %}" class="btn btn-secondary">{% trans 'Submit Talk Proposal' %}</a></li>
+               {% endif %}
+             </ul>
+           {% endif %}
+         {% endblock side_menu %}
         {% spaceless %}
         <h1>
           {% if profile.homepage %}
@@ -56,20 +58,22 @@
             </a>
           {% endif %}
         </h1>
-        {% if profile.twitter_handle %}
-          <p>
-            <a href="https://twitter.com/{{ profile.twitter_handle }}" class="twitter-follow-button" data-bs-show-count="false">
-              {% blocktrans with handle=profile.twitter_handle %}Follow @{{ handle }}{% endblocktrans %}
-            </a>
-          </p>
-        {% endif %}
-        {% if profile.github_username %}
-          <p>
-            <a href="https://github.com/{{ profile.github_username }}">
-              {% blocktrans with username=profile.github_username %}GitHub: {{ username }}{% endblocktrans %}
-            </a>
-          </p>
-        {% endif %}
+        {% block social %}
+           {% if profile.twitter_handle %}
+             <p>
+               <a href="https://twitter.com/{{ profile.twitter_handle }}" class="twitter-follow-button" data-bs-show-count="false">
+                 {% blocktrans with handle=profile.twitter_handle %}Follow @{{ handle }}{% endblocktrans %}
+               </a>
+             </p>
+           {% endif %}
+           {% if profile.github_username %}
+             <p>
+               <a href="https://github.com/{{ profile.github_username }}">
+                 {% blocktrans with username=profile.github_username %}GitHub: {{ username }}{% endblocktrans %}
+               </a>
+             </p>
+           {% endif %}
+        {% endblock social %}
         {% endspaceless %}
       </div>
     </div>
@@ -80,23 +84,25 @@
     {% endif %}
     {% if can_edit %}
       {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
-        {% if profile.is_registered %}
-          <div class="alert alert-success">
-            {% blocktrans trimmed %}
-              Registered
-            {% endblocktrans %}
-          </div>
-        {% else %}
-          <div class="alert alert-danger">
-            {% blocktrans trimmed %}
-              <strong>WARNING:</strong>
-              Talk proposal submitted, but speaker hasn't registered to attend.
-            {% endblocktrans %}
-            {% if WAFER_REGISTRATION_OPEN %}
-              {% trans "Register now!" %}
-            {% endif %}
-          </div>
-        {% endif %}
+        {% block speaker_registered %}
+           {% if profile.is_registered %}
+             <div class="alert alert-success">
+               {% blocktrans trimmed %}
+                 Registered
+               {% endblocktrans %}
+             </div>
+           {% else %}
+             <div class="alert alert-danger">
+               {% blocktrans trimmed %}
+                 <strong>WARNING:</strong>
+                 Talk proposal submitted, but speaker hasn't registered to attend.
+               {% endblocktrans %}
+               {% if WAFER_REGISTRATION_OPEN %}
+                 {% trans "Register now!" %}
+               {% endif %}
+             </div>
+           {% endif %}
+        {% endblock speaker_registered %}
       {% endif %}
     {% endif %}
     {# Accepted talks are globally visible #}

--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -102,8 +102,10 @@
                {% endif %}
              </div>
            {% endif %}
-           {% if WAFER_REGISTRATION_MODE == 'ticket' and profile.is_registered  %}
-              {{ profile.tickets }}
+           {% if WAFER_REGISTRATION_MODE == 'ticket' and profile.is_registered %}
+           <p>Tickets:
+              {{ profile.ticket_types }}
+           </p>
            {% endif %}
         {% endblock speaker_registered %}
       {% endif %}


### PR DESCRIPTION
To address #642 , this adds the tickets associated with a user to the profile.

This also tweaks the logic for associating tickets with a user so that different ticket types (conference, tutorial, etc) have fewer cases where the user will have to manually claim the ticket.

The actual UI part of the profile needs some love.