### PR TITLE
Feature/drop django before 3.2

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,7 +27,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        django-version: ['2.2.0', '3.0.0', '3.1.0', '3.2.0', '4.0.0', '4.1.0', 'main']
+        django-version: ['3.2.0', '4.0.0', '4.1.0', 'main']
         exclude:
           - django-version: '4.0.0'
             python-version: '3.7'
@@ -39,14 +39,6 @@ jobs:
             python-version: '3.8'
           - django-version: 'main'
             python-version: '3.9'
-          - django-version: '2.2.0'
-            python-version: '3.10'
-          - django-version: '2.2.0'
-            python-version: '3.11'
-          - django-version: '3.0.0'
-            python-version: '3.11'
-          - django-version: '3.1.0'
-            python-version: '3.11'
           - django-version: '3.2.0'
             python-version: '3.11'
           - django-version: '4.0.0'
@@ -98,7 +90,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10','3.11']
-        django-version: ['2.2.0', '3.0.0', '3.1.0', '3.2.0', '4.0.0', '4.1.0', 'main']
+        django-version: ['3.2.0', '4.0.0', '4.1.0', 'main']
         exclude:
           - django-version: '4.0.0'
             python-version: '3.7'
@@ -110,14 +102,6 @@ jobs:
             python-version: '3.8'
           - django-version: 'main'
             python-version: '3.9'
-          - django-version: '2.2.0'
-            python-version: '3.10'
-          - django-version: '2.2.0'
-            python-version: '3.11'
-          - django-version: '3.0.0'
-            python-version: '3.11'
-          - django-version: '3.1.0'
-            python-version: '3.11'
           - django-version: '3.2.0'
             python-version: '3.11'
           - django-version: '4.0.0'

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,11 +27,15 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        django-version: ['3.2.0', '4.0.0', '4.1.0', 'main']
+        django-version: ['3.2.0', '4.0.0', '4.1.0', '4.2.0', 'main']
         exclude:
           - django-version: '4.0.0'
             python-version: '3.7'
           - django-version: '4.1.0'
+            python-version: '3.7'
+          - django-version: '4.2.0'
+            python-version: '3.8'
+          - django-version: '4.2.0'
             python-version: '3.7'
           - django-version: 'main'
             python-version: '3.7'
@@ -90,12 +94,16 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10','3.11']
-        django-version: ['3.2.0', '4.0.0', '4.1.0', 'main']
+        django-version: ['3.2.0', '4.0.0', '4.1.0', '4.2.0', 'main']
         exclude:
           - django-version: '4.0.0'
             python-version: '3.7'
           - django-version: '4.1.0'
             python-version: '3.7'
+          - django-version: '4.2.0'
+            python-version: '3.7'
+          - django-version: '4.2.0'
+            python-version: '3.8'
           - django-version: 'main'
             python-version: '3.7'
           - django-version: 'main'

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Available on `readthedocs.org`_.
 Supported Django versions
 =========================
 
-Wafer supports Django 2.2, Django 3.0 - 3.2 and Django 4.0 - 4.1.
+Wafer supports Django 3.2 and Django 4.0 - 4.2.
 
 Installation
 ============

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Supported versions
 ==================
 
-Wafer supports Django 2.2, 3.0-3.2, 4.0-4.1 and Python 3.6 to 3.10.
+Wafer supports Django 3.2, 4.0-4.2 and Python 3.7 to 3.11.
 
 Requirements
 ============

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import subprocess
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=2.2,<5',
+    'Django>=3.2,<5',
     'bleach',
     'bleach-allowlist',
     'crispy-bootstrap5',


### PR DESCRIPTION
While it is possible to run wafer with Django before 3.2, it requires a bunch of extra fiddling because several of our dependencies have dropped support for old django versions, including the defaults we use of crispy forms.

Given that Django 3.1 reach EOL in Dec 2021, and 2.2 in April 2022, there doesn't seem to be much value in keeping these as "officially supported"

This PR also adds 4.2 as a supported release, since there's nothing that changed from 4.1 that should break wafer, local testing seems fine and the tests all pass.