### PR TITLE
Feature/selenium tests for schedule editor

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -83,7 +83,7 @@ jobs:
         TESTDB: postgres
       run: |
         export PYTHONWARNINGS=always
-        coverage run --source='wafer' manage.py test && coverage report --skip-covered
+        coverage run --source='wafer' manage.py test --exclude-tag selenium && coverage report --skip-covered
 
   sqlite:
 
@@ -138,7 +138,7 @@ jobs:
       continue-on-error: ${{ matrix.django-version == 'main' }}
       run: |
         export PYTHONWARNINGS=always
-        coverage run --source='wafer' manage.py test && coverage report --skip-covered
+        coverage run --source='wafer' manage.py test --exclude-tag selenium && coverage report --skip-covered
 
   translations:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -118,3 +118,16 @@ Translation
 Translations for wafer are managed at `weblate.org`_
 
 .. _weblate.org: https://hosted.weblate.org/projects/wafer/
+
+
+Selenium tests
+==============
+
+wafer includes a small set of selenium tests to test various bits of javascript
+used in the site (mostly in the schedule editor).
+
+To run the tests, you will need to install selenium - ``pip install selenium``
+and also run ``rpm install`` to install the required javascript dependencies.
+
+The tests can be run using the ``selenium`` tag, or using the individual browser
+tags (currently ``firefox`` and ``chrome``).

--- a/wafer/schedule/tests/test_schedule_datetime_widget.py
+++ b/wafer/schedule/tests/test_schedule_datetime_widget.py
@@ -1,6 +1,19 @@
 import datetime as D
 
+try:
+    from selenium.webdriver.common.keys import Keys
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions
+except ImportError:
+    # These need to be non-fatal so the tests can be always loaded
+    # and the check in the Runner base class will fail these
+    # if stuff isn't loaded
+    pass
+
+
 from django.utils import timezone
+from django.urls import reverse
 
 from wafer.pages.models import Page
 from wafer.tests.utils import ChromeTestRunner, FirefoxTestRunner
@@ -10,32 +23,52 @@ from wafer.schedule.tests.test_views import make_pages, make_items
 
 
 class ScheduleDateTimeJSMixin:
-    """Test the custom datetime widget"""
+    """Test the custom datetime entries work as expected"""
 
     def setUp(self):
         """Create venue, block and slots so we use the slot admin page"""
         super().setUp()
-        block1 = ScheduleBlock.objects.create(
+        self.block1 = ScheduleBlock.objects.create(
             start_time=D.datetime(2013, 9, 22, 7, 0, 0,
                                   tzinfo=D.timezone.utc),
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
                                 tzinfo=D.timezone.utc),
             )
         venue1 = Venue.objects.create(order=1, name='Venue 1')
-        venue1.blocks.add(block1)
+        venue1.blocks.add(self.block1)
 
-        slot1 =  Slot(start_time=D.datetime(2013, 9, 22, 12, 0, 0,
+        self.slot1 =  Slot(start_time=D.datetime(2013, 9, 22, 12, 0, 0,
                                             tzinfo=D.timezone.utc),
                       end_time=D.datetime(2013, 9, 22, 13, 0, 0,
                                           tzinfo=D.timezone.utc))
-        slot2 =  Slot(previous_slot=slot1,
+        self.slot2 =  Slot(previous_slot=self.slot1,
                       end_time=D.datetime(2013, 9, 22, 14, 0, 0,
                                           tzinfo=D.timezone.utc))
 
-    def test_datetime_widget(self):
+    def test_datetime_widget_slot_admin(self):
         """Test that the datetime widget lists the desired times"""
         self.admin_login()
-    
+        # Navigate to the slot list page
+        slot_admin_list_url = reverse('admin:schedule_slot_changelist')
+        self.driver.get(f"{self.live_server_url}{slot_admin_list_url}")
+        # select the time widget
+        # Confirm that the expected entries are there
+        # Navigate to an indivual slot page
+        # We need to specify kwargs as an explicit dict
+        slot_admin_change_url = reverse('admin:schedule_slot_change',
+                                        kwargs={'object_id': self.slot1.id})
+        self.driver.get(f"{self.live_server_url}{slot_admin_change_url}")
+        # Also check the widget there
+
+    def test_datetime_widget_schedule_block_admin(self):
+        """Test that the datetime widget lists the desired times"""
+        self.admin_login()
+        # Navigate to the schedule block page
+        block_admin_change_url = reverse('admin:schedule_scheduleblock_change',
+                                         kwargs={'object_id': self.block1.id})
+        self.driver.get(f"{self.live_server_url}{block_admin_change_url}")
+        # Check the widget there
+
 
 class ChromeScheduleEditorTests(ScheduleDateTimeJSMixin, ChromeTestRunner):
     pass

--- a/wafer/schedule/tests/test_schedule_datetime_widget.py
+++ b/wafer/schedule/tests/test_schedule_datetime_widget.py
@@ -5,6 +5,7 @@ try:
     from selenium.webdriver.common.by import By
     from selenium.webdriver.support.ui import WebDriverWait
     from selenium.webdriver.support import expected_conditions
+    from selenium.common.exceptions import NoSuchElementException
 except ImportError:
     # These need to be non-fatal so the tests can be always loaded
     # and the check in the Runner base class will fail these
@@ -34,6 +35,7 @@ class ScheduleDateTimeJSMixin:
             end_time=D.datetime(2013, 9, 22, 19, 0, 0,
                                 tzinfo=D.timezone.utc),
             )
+        self.block1.save()
         venue1 = Venue.objects.create(order=1, name='Venue 1')
         venue1.blocks.add(self.block1)
 
@@ -41,24 +43,53 @@ class ScheduleDateTimeJSMixin:
                                             tzinfo=D.timezone.utc),
                       end_time=D.datetime(2013, 9, 22, 13, 0, 0,
                                           tzinfo=D.timezone.utc))
+        self.slot1.save()
         self.slot2 =  Slot(previous_slot=self.slot1,
                       end_time=D.datetime(2013, 9, 22, 14, 0, 0,
                                           tzinfo=D.timezone.utc))
 
-    def test_datetime_widget_slot_admin(self):
-        """Test that the datetime widget lists the desired times"""
+    def check_clock_button(self):
+        """Standard check for the clock button contents"""
+        # Find the clock button
+        clock_button = WebDriverWait(self.driver, 10).until(
+            expected_conditions.presence_of_element_located((By.CLASS_NAME, 'clock-icon'))
+        )
+        # Check that the list isn't visible before we click
+        clock_box = self.driver.find_element(By.ID, 'clockbox0')
+        style = clock_box.get_attribute('style')
+        self.assertIn('display: none', style)
+        clock_button.click()
+        timelist =  WebDriverWait(self.driver, 10).until(
+            expected_conditions.presence_of_element_located((By.CLASS_NAME, 'timelist'))
+        )
+        clock_box = self.driver.find_element(By.ID, 'clockbox0')
+        style = clock_box.get_attribute('style')
+        self.assertIn('display: block', style)
+        seen_times = []
+        for li in timelist.find_elements(By.TAG_NAME, 'li'):
+            ahref = li.find_element(By.TAG_NAME, 'a')
+            seen_times.append(ahref.text.strip())
+        for time in range(8, 21):
+            time_str = f'{time:02d}:00'
+            self.assertIn(time_str, seen_times)
+
+    def test_datetime_widget_slot_admin_changelist(self):
+        """Test that the datetime widget lists the desired times in the list view"""
         self.admin_login()
         # Navigate to the slot list page
         slot_admin_list_url = reverse('admin:schedule_slot_changelist')
         self.driver.get(f"{self.live_server_url}{slot_admin_list_url}")
-        # select the time widget
-        # Confirm that the expected entries are there
-        # Navigate to an indivual slot page
+        self.check_clock_button()
+
+    def test_datetime_widget_slot_admin_change(self):
+        """Test that the datetime widget lists the desired times
+           on the individual slot admin page"""
         # We need to specify kwargs as an explicit dict
+        self.admin_login()
         slot_admin_change_url = reverse('admin:schedule_slot_change',
-                                        kwargs={'object_id': self.slot1.id})
+                                        kwargs={'object_id': self.slot1.pk})
         self.driver.get(f"{self.live_server_url}{slot_admin_change_url}")
-        # Also check the widget there
+        self.check_clock_button()
 
     def test_datetime_widget_schedule_block_admin(self):
         """Test that the datetime widget lists the desired times"""
@@ -67,7 +98,7 @@ class ScheduleDateTimeJSMixin:
         block_admin_change_url = reverse('admin:schedule_scheduleblock_change',
                                          kwargs={'object_id': self.block1.id})
         self.driver.get(f"{self.live_server_url}{block_admin_change_url}")
-        # Check the widget there
+        self.check_clock_button()
 
 
 class ChromeScheduleEditorTests(ScheduleDateTimeJSMixin, ChromeTestRunner):

--- a/wafer/schedule/tests/test_schedule_datetime_widget.py
+++ b/wafer/schedule/tests/test_schedule_datetime_widget.py
@@ -1,0 +1,45 @@
+import datetime as D
+
+from django.utils import timezone
+
+from wafer.pages.models import Page
+from wafer.tests.utils import ChromeTestRunner, FirefoxTestRunner
+
+from wafer.schedule.models import Venue, Slot, ScheduleBlock
+from wafer.schedule.tests.test_views import make_pages, make_items
+
+
+class ScheduleDateTimeJSMixin:
+    """Test the custom datetime widget"""
+
+    def setUp(self):
+        """Create venue, block and slots so we use the slot admin page"""
+        super().setUp()
+        block1 = ScheduleBlock.objects.create(
+            start_time=D.datetime(2013, 9, 22, 7, 0, 0,
+                                  tzinfo=D.timezone.utc),
+            end_time=D.datetime(2013, 9, 22, 19, 0, 0,
+                                tzinfo=D.timezone.utc),
+            )
+        venue1 = Venue.objects.create(order=1, name='Venue 1')
+        venue1.blocks.add(block1)
+
+        slot1 =  Slot(start_time=D.datetime(2013, 9, 22, 12, 0, 0,
+                                            tzinfo=D.timezone.utc),
+                      end_time=D.datetime(2013, 9, 22, 13, 0, 0,
+                                          tzinfo=D.timezone.utc))
+        slot2 =  Slot(previous_slot=slot1,
+                      end_time=D.datetime(2013, 9, 22, 14, 0, 0,
+                                          tzinfo=D.timezone.utc))
+
+    def test_datetime_widget(self):
+        """Test that the datetime widget lists the desired times"""
+        self.admin_login()
+    
+
+class ChromeScheduleEditorTests(ScheduleDateTimeJSMixin, ChromeTestRunner):
+    pass
+
+
+class FirefoxSchedultEditorTests(ScheduleDateTimeJSMixin, FirefoxTestRunner):
+    pass

--- a/wafer/schedule/tests/test_schedule_editor.py
+++ b/wafer/schedule/tests/test_schedule_editor.py
@@ -299,31 +299,40 @@ class EditorTestsMixin:
         self.assertEqual(item.page, self.pages[11])
         # Check that this hasn't changed the page tab list
         post_drag_tab_items = []
-        found = False
+        found1 = False
+        found2 = False
         for x in tab_pane.find_elements(By.CLASS_NAME, 'draggable'):
             if 'test page 5' in x.text:
-                found = True
+                found1 = True
             if 'test page 11' in x.text:
-                found = True
+                found2 = True
             post_drag_tab_items.append(x.text)
-        self.assertTrue(found)
+        self.assertTrue(found1)
+        self.assertTrue(found2)
         self.assertEqual(tab_items, post_drag_tab_items)
 
     def test_swicth_day(self):
         """Test selecting different days"""
+        # Create a couple of schedule items on each day
+        # Load schedule page
         self.admin_login()
         self.driver.get(self.edit_page)
+        # Verify we see the expected schedule items on day 1
+        # Switch day
+        # Verify we see the expected schedule items on day 2
+
 
     def test_drag_over(self):
         """Test that dragging over an item replaces it"""
+        # Create a schedule with a single item
         self.admin_login()
         self.driver.get(self.edit_page)
-        # Check that unassigned list is updated correctly
         # Test dragging a talk over an existing talk
         # Check that unassigned list is updated correctly
 
     def test_drag_over_page(self):
         """Test that dragging over a page with another page works"""
+        # Create a schedule with a single item
         self.admin_login()
         self.driver.get(self.edit_page)
         # Test dragging a page over an existing page

--- a/wafer/schedule/tests/test_schedule_editor.py
+++ b/wafer/schedule/tests/test_schedule_editor.py
@@ -15,6 +15,8 @@ except ImportError:
     # if stuff isn't loaded
     pass
 
+from unittest import expectedFailure
+
 from django.utils import timezone
 from django.urls import reverse
 
@@ -114,7 +116,7 @@ class EditorTestsMixin:
         b2_slot3 = Slot(previous_slot=b2_slot2,
                         end_time=b2_end)
 
-        self.pages = make_pages(12)
+        self.pages = make_pages(6)
 
         self.block1_slots = [b1_slot1, b1_slot2, b1_slot3]
         self.block2_slots = [b2_slot1, b2_slot2, b2_slot3]
@@ -256,7 +258,7 @@ class EditorTestsMixin:
         tab_items = []
         for x in tab_pane.find_elements(By.CLASS_NAME, 'draggable'):
             # We choose page 5 so we're dragging from the middle of the list
-            if 'test page 5' in x.text:
+            if 'test page 3' in x.text:
                 source = x
             tab_items.append(x.text)
         # Find the first schedule item in the schedule tabls
@@ -270,19 +272,19 @@ class EditorTestsMixin:
         )
         self.assertEqual(ScheduleItem.objects.count(), 1)
         item = ScheduleItem.objects.first()
-        self.assertEqual(item.page, self.pages[5])
+        self.assertEqual(item.page, self.pages[3])
         # Check that this hasn't changed the page tab list
         post_drag_tab_items = []
         found = False
         for x in tab_pane.find_elements(By.CLASS_NAME, 'draggable'):
-            if 'test page 5' in x.text:
+            if 'test page 3' in x.text:
                 found = True
             post_drag_tab_items.append(x.text)
         self.assertTrue(found)
         self.assertEqual(tab_items, post_drag_tab_items)
         # Try drag the last page
         for x in tab_pane.find_elements(By.CLASS_NAME, 'draggable'):
-            if 'test page 11' in x.text:
+            if 'test page 5' in x.text:
                 source = x
                 break
         # Find the first schedule item in the schedule tabls
@@ -296,15 +298,15 @@ class EditorTestsMixin:
         )
         self.assertEqual(ScheduleItem.objects.count(), 2)
         item = ScheduleItem.objects.last()
-        self.assertEqual(item.page, self.pages[11])
+        self.assertEqual(item.page, self.pages[5])
         # Check that this hasn't changed the page tab list
         post_drag_tab_items = []
         found1 = False
         found2 = False
         for x in tab_pane.find_elements(By.CLASS_NAME, 'draggable'):
-            if 'test page 5' in x.text:
+            if 'test page 3' in x.text:
                 found1 = True
-            if 'test page 11' in x.text:
+            if 'test page 5' in x.text:
                 found2 = True
             post_drag_tab_items.append(x.text)
         self.assertTrue(found1)
@@ -321,14 +323,16 @@ class EditorTestsMixin:
         # Switch day
         # Verify we see the expected schedule items on day 2
 
-
-    def test_drag_over(self):
+    @expectedFailure
+    def test_drag_over_talk(self):
         """Test that dragging over an item replaces it"""
+        # Expected to fail - see https://github.com/CTPUG/wafer/issues/689
         # Create a schedule with a single item
         self.admin_login()
         self.driver.get(self.edit_page)
         # Test dragging a talk over an existing talk
         # Check that unassigned list is updated correctly
+        # FIXME: The schedule editor doesn't do this correctly
 
     def test_drag_over_page(self):
         """Test that dragging over a page with another page works"""
@@ -338,10 +342,30 @@ class EditorTestsMixin:
         # Test dragging a page over an existing page
         # Check that page list is unchanged
 
-    def test_create_invalid_schedule(self):
-        """Test that an invalid schedule displays the errors"""
+    @expectedFailure
+    def test_adding_clash(self):
+        """Test that introducing a speaker clash causes the
+           error section to be updated"""
+        # Expected to fail -see https://github.com/CTPUG/wafer/issues/158
+        # Create initial schedule
         self.admin_login()
         self.driver.get(self.edit_page)
+        # Drag a talk into a clashing slot
+        # Verify errors are present
+        # FIXME: The schedule editor doesn't currently update this
+
+    @expectedFailure
+    def test_removing_clash(self):
+        """Test that removing a speaker clash causes the
+           error section to be cleared"""
+        # Expected to fail -see https://github.com/CTPUG/wafer/issues/158
+        # Create initial schedule
+        self.admin_login()
+        self.driver.get(self.edit_page)
+        # Verify we have the expected errors
+        # Delete one of the clashes
+        # Verify errors are gone
+        # FIXME: The schedule editor doesn't currently update this
 
 
 class ChromeScheduleEditorTests(EditorTestsMixin, ChromeTestRunner):

--- a/wafer/schedule/tests/test_schedule_editor.py
+++ b/wafer/schedule/tests/test_schedule_editor.py
@@ -1,0 +1,158 @@
+import datetime as D
+
+from django.utils import timezone
+
+from wafer.pages.models import Page
+from wafer.tests.utils import create_user, ChromeTestRunner, FirefoxTestRunner
+from wafer.talks.tests.fixtures import create_talk
+from wafer.talks.models import ACCEPTED
+
+from wafer.schedule.models import ScheduleBlock, Venue, Slot, ScheduleItem
+from wafer.schedule.tests.test_views import make_pages, make_items
+
+
+class EditorTestsMixin:
+    """Define the schedule editor tests independant of the
+       selenium webdriver.
+
+       This is combined with the appropriate helper class
+       to create the actual test cases."""
+
+    def setUp(self):
+        """Create two day table with 3 slots each and 2 venues
+           and create some page and talks to populate the schedul"""
+        super().setUp()
+        # Schedule is
+        # Day1
+        #         Venue 1     Venue 2
+        # 10-11   Item1       Item4
+        # 11-12   Item2       Item5
+        # 12-13   Item3       Item6
+        # Day 2 
+        #         Venue 1     Venue 2   Venue 3
+        # 10-11   Item7       Item10    Item13
+        # 11-12   Item8       Item11    Item14
+        # 12-13   Item9       Item12    Item15
+        block1 = ScheduleBlock.objects.create(
+            start_time=D.datetime(2013, 9, 22, 7, 0, 0,
+                                  tzinfo=D.timezone.utc),
+            end_time=D.datetime(2013, 9, 22, 19, 0, 0,
+                                tzinfo=D.timezone.utc),
+            )
+
+        block2 = ScheduleBlock.objects.create(
+            start_time=D.datetime(2013, 9, 23, 7, 0, 0,
+                                  tzinfo=D.timezone.utc),
+            end_time=D.datetime(2013, 9, 23, 19, 0, 0,
+                                tzinfo=D.timezone.utc),
+            )
+
+        venue1 = Venue.objects.create(order=1, name='Venue 1')
+        venue1.blocks.add(block1)
+        venue1.blocks.add(block2)
+
+        venue2 = Venue.objects.create(order=2, name='Venue 2')
+        venue2.blocks.add(block1)
+        venue2.blocks.add(block2)
+
+        venue3 = Venue.objects.create(order=3, name='Venue 3')
+        venue3.blocks.add(block2)
+
+        self.venues = [venue1, venue2, venue3]
+
+        b1_start1 = D.datetime(2013, 9, 22, 10, 0, 0,
+                               tzinfo=D.timezone.utc)
+        b1_start2 = D.datetime(2013, 9, 22, 11, 0, 0,
+                               tzinfo=D.timezone.utc)
+        b1_start3 = D.datetime(2013, 9, 22, 12, 0, 0,
+                               tzinfo=D.timezone.utc)
+        b1_end = D.datetime(2013, 9, 22, 13, 0, 0,
+                            tzinfo=D.timezone.utc)
+
+        b1_slot1 = Slot(start_time=b1_start1,
+                        end_time=b1_start2)
+        b1_slot2 = Slot(previous_slot=b1_slot1,
+                        end_time=b1_start3)
+        b1_slot3 = Slot(previous_slot=b1_slot2,
+                        end_time=b1_end)
+
+        b2_start1 = D.datetime(2013, 9, 23, 10, 0, 0,
+                               tzinfo=D.timezone.utc)
+        b2_start2 = D.datetime(2013, 9, 23, 11, 0, 0,
+                               tzinfo=D.timezone.utc)
+        b2_start3 = D.datetime(2013, 9, 23, 12, 0, 0,
+                               tzinfo=D.timezone.utc)
+        b2_end = D.datetime(2013, 9, 23, 13, 0, 0,
+                            tzinfo=D.timezone.utc)
+
+        b2_slot1 = Slot(start_time=b2_start1,
+                       end_time=b2_start2)
+        b2_slot2 = Slot(previous_slot=b2_slot1,
+                        end_time=b2_start3)
+        b2_slot3 = Slot(previous_slot=b2_slot2,
+                        end_time=b2_end)
+
+        self.pages = make_pages(12)
+
+        self.block1_slots = [b1_slot1, b1_slot2, b1_slot3]
+        self.block2_slots = [b2_slot1, b2_slot2, b2_slot3]
+
+        self.talk1 = create_talk('Test talk 1', status=ACCEPTED, username='john')
+        self.talk2 = create_talk('Test talk 2', status=ACCEPTED, username='james')
+        self.talk3 = create_talk('Test talk 3', status=ACCEPTED, username='jess')
+        self.talk4 = create_talk('Test talk 4', status=ACCEPTED, username='jonah')
+
+    def test_access_schedule_editor_no_login(self):
+        """Test that the schedule editor isn't accessible if not logged in"""
+
+    def test_access_schedule_editor_no_super(self):
+        """Test that the schedule editor isn't accessible for non-superuser accounts"""
+        self.normal_login()
+
+    def test_access_schedule_editor_admin(self):
+        """Test that the schedule editor is accessible for superuser accounts"""
+        self.admin_login()
+
+    def test_drag_talk(self):
+        """Test dragging talk behavior"""
+        self.admin_login()
+        # Drag a talk from the siderbar to a slot in the schedule
+        # Check that dragged talk is not on the list of unassigned talks
+        # Drag a talk from one slot to another
+
+    def test_drag_page(self):
+        """Test dragging page behavior"""
+        self.admin_login()
+        # Drag a page from the siderbar to a slot in the schedule
+        # Check that this doesn't change the unassigned list
+        # Drag a page from one spot to another
+
+    def test_swicth_day(self):
+        """Test selecting different days"""
+        self.admin_login()
+
+    def test_remove_talk(self):
+        """Test removing talks"""
+        self.admin_login()
+        # Test delete button
+        # Check that unassigned list is updated correctly
+        # Test dragging a talk over an existing talk
+        # Check that unassigned list is updated correctly
+
+    def test_remove_page(self):
+        """Test removing pages"""
+        self.admin_login()
+        # Test delete button
+        # Test dragging a page over an existing page
+
+    def test_create_invalid_schedule(self):
+        """Test that an invalid schedule displays the errors"""
+        self.admin_login()
+    
+
+class ChromeScheduleEditorTests(EditorTestsMixin, ChromeTestRunner):
+    pass
+
+
+class FirefoxSchedultEditorTests(EditorTestsMixin, FirefoxTestRunner):
+    pass

--- a/wafer/tests/utils.py
+++ b/wafer/tests/utils.py
@@ -2,6 +2,14 @@
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.test import tag
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
+try:
+    # Guard for running this without selenium installed
+    from selenium import webdriver
+except ImportError:
+    selenium = None
 
 
 def get_group(group):
@@ -36,3 +44,38 @@ def mock_avatar_url(self):
     if self.user.email is None:
         return None
     return "avatar-%s" % self.user.email
+
+@tag('selenium')
+class BaseWebdriverRunner(StaticLiveServerTestCase):
+
+    def setUp(self):
+        """Create an ordinary user and an admin user for testing"""
+        if not selenium:
+            raise RuntimeError("Test requires selenium installed")
+        super().setUp()
+        self.admin_user = create_user('admin', email='admin@localhost', superuser=True)
+        self.admin_password = 'admin_password'
+        self.normal_user = create_user('normal', email='normal@localhost', superuser=False)
+        self.normal_password = 'normal_password'
+
+    def normal_login(self):
+        """Login as an ordinary user"""
+
+    def admin_login(self):
+        """Login as the admin user"""
+
+
+@tag('chrome')
+class ChromeTestRunner(BaseWebdriverRunner):
+
+    def setUp(self):
+        super().setUp()
+        # Load the chrome webdriver
+
+
+@tag('firefox')
+class FirefoxTestRunner(BaseWebdriverRunner):
+
+    def setUp(self):
+        super().setUp()
+        # Load the firefox webdriver

--- a/wafer/tests/utils.py
+++ b/wafer/tests/utils.py
@@ -1,5 +1,6 @@
 """Utilities for testing wafer."""
 
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.test import tag
@@ -68,7 +69,8 @@ class BaseWebdriverRunner(StaticLiveServerTestCase):
 
     def _login(self, name, password):
         """Generic login handler"""
-        self.driver.get(f"{self.live_server_url}/accounts/login/")
+        login_url = reverse('auth_login')
+        self.driver.get(f"{self.live_server_url}{login_url}")
         WebDriverWait(self.driver, 10).until(
             expected_conditions.presence_of_element_located((By.NAME, "submit"))
         )
@@ -91,6 +93,9 @@ class BaseWebdriverRunner(StaticLiveServerTestCase):
         """Login as the admin user"""
         self._login(self.admin_user.username, self.admin_password)
 
+    def tearDown(self):
+        self.driver.close()
+
 
 @tag('chrome')
 class ChromeTestRunner(BaseWebdriverRunner):
@@ -101,6 +106,7 @@ class ChromeTestRunner(BaseWebdriverRunner):
         self.options = webdriver.ChromeOptions()
         self.options.add_argument("--headless=new")
         self.driver = webdriver.Chrome(options=self.options)
+
 
 @tag('firefox')
 class FirefoxTestRunner(BaseWebdriverRunner):

--- a/wafer/tests/utils.py
+++ b/wafer/tests/utils.py
@@ -5,11 +5,17 @@ from django.contrib.auth.models import Group, Permission
 from django.test import tag
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 
+from wafer.users.models import PROFILE_GROUP
+
 try:
     # Guard for running this without selenium installed
     from selenium import webdriver
+    from selenium.webdriver.common.keys import Keys
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions
 except ImportError:
-    selenium = None
+    webdriver = None
 
 
 def get_group(group):
@@ -50,19 +56,40 @@ class BaseWebdriverRunner(StaticLiveServerTestCase):
 
     def setUp(self):
         """Create an ordinary user and an admin user for testing"""
-        if not selenium:
+        if not webdriver:
             raise RuntimeError("Test requires selenium installed")
         super().setUp()
         self.admin_user = create_user('admin', email='admin@localhost', superuser=True)
         self.admin_password = 'admin_password'
         self.normal_user = create_user('normal', email='normal@localhost', superuser=False)
         self.normal_password = 'normal_password'
+        # Required to load the user profile page because of the key-value fields
+        create_group(PROFILE_GROUP)
+
+    def _login(self, name, password):
+        """Generic login handler"""
+        self.driver.get(f"{self.live_server_url}/accounts/login/")
+        WebDriverWait(self.driver, 10).until(
+            expected_conditions.presence_of_element_located((By.NAME, "submit"))
+        )
+        user_field = self.driver.find_element(By.NAME, 'username')
+        user_field.send_keys(name)
+        pass_field = self.driver.find_element(By.NAME, 'password')
+        pass_field.send_keys(password)
+        loginbut = self.driver.find_element(By.NAME, 'submit')
+        loginbut.click()
+        #self.driver.get(f"{self.live_server_url}/")
+        WebDriverWait(self.driver, 10).until(
+            expected_conditions.presence_of_element_located((By.PARTIAL_LINK_TEXT, "Log out"))
+        )
 
     def normal_login(self):
         """Login as an ordinary user"""
+        self._login(self.normal_user.username, self.normal_password)
 
     def admin_login(self):
         """Login as the admin user"""
+        self._login(self.admin_user.username, self.admin_password)
 
 
 @tag('chrome')
@@ -71,7 +98,9 @@ class ChromeTestRunner(BaseWebdriverRunner):
     def setUp(self):
         super().setUp()
         # Load the chrome webdriver
-
+        self.options = webdriver.ChromeOptions()
+        self.options.add_argument("--headless=new")
+        self.driver = webdriver.Chrome(options=self.options)
 
 @tag('firefox')
 class FirefoxTestRunner(BaseWebdriverRunner):
@@ -79,3 +108,11 @@ class FirefoxTestRunner(BaseWebdriverRunner):
     def setUp(self):
         super().setUp()
         # Load the firefox webdriver
+        self.options = webdriver.FirefoxOptions()
+        self.options.add_argument('-headless')
+        # Disable options that may break selenium
+        # see https://github.com/mozilla/geckodriver/releases/tag/v0.33.0 and
+        # https://github.com/SeleniumHQ/selenium/issues/11736
+        self.options.set_preference('fission.bfcacheInParent', False)
+        self.options.set_preference('fission.webContentIsolationStrategy', 0)
+        self.driver = webdriver.Firefox(options=self.options)


### PR DESCRIPTION
This adds some tests using selenium to exercise some of our cutom ajvascript code (our custom datetime widget & the schedule editor)

Closes: #159 

Some notes:

I've marked as expected failures some cases where the schedule editor behavior isn't correct (See #689 and #158 ). 

Firefox and drag and drop with selenium seems flakey at the moment - see failures at https://wpt.fyi/results/webdriver/tests/bidi/input/perform_actions/pointer_mouse_drag.py?label=experimental&label=master&aligned and related issues like https://bugzilla.mozilla.org/show_bug.cgi?id=1515879 -  hopefully this wlll get better 

We will need to add more support for customising the webdriver config, to support things like using browsers in snaps on ubuntu and so forth.

I haven't looked at what's required to run these via github actions yet.