### PR TITLE
Feature/gh actions selenium tests

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -160,3 +160,41 @@ jobs:
       run: |
         cd wafer
         python ../manage.py compilemessages
+
+
+
+  selenium:
+
+    runs-on: ubuntu-latest
+
+    name: Selenium - Browser ${{ matrix.browser }}
+    strategy:
+      max-parallel: 2
+      matrix:
+        browser: ['chrome', 'firefox']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+        pip install selenium
+    - name: Install node
+      uses: actions/setup-node@v4
+    - name: Install javascript dependencies
+      run: |
+        npm install
+    - name: Setup Chrome
+      uses: browser-actions/setup-chrome@v1
+      if: matrix.browser == 'chrome'
+    - name: Setup firefox
+      run: |
+        wget -O firefox.tar.bz2 'https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US'
+        tar xaf firefox.tar.bz2
+        export PATH=$PATH:${PWD}/firefox
+      if: matrix.browser == 'firefox'
+    - name: Run Tests
+      run: |
+        python manage.py test --tag ${{ matrix.browser }}

--- a/wafer/schedule/tests/test_schedule_editor.py
+++ b/wafer/schedule/tests/test_schedule_editor.py
@@ -552,4 +552,28 @@ class ChromeScheduleEditorTests(EditorTestsMixin, ChromeTestRunner):
 
 
 class FirefoxSchedultEditorTests(EditorTestsMixin, FirefoxTestRunner):
-    pass
+    # We explictly mark the tests we expect due to
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1515879
+    # as expectedFailure, so we can run these in github actions
+    # with sensible results (and hopefully see when the bug gets
+    # fixed).
+
+    @expectedFailure
+    def test_drag_talk(self):
+        super().test_drag_talk()
+
+    @expectedFailure
+    def test_drag_page(self):
+        super().test_drag_page()
+
+    @expectedFailure
+    def test_drag_over_talk(self):
+        super().test_drag_over_talk()
+
+    @expectedFailure
+    def test_drag_over_page(self):
+        super().test_drag_over_page()
+
+    @expectedFailure
+    def test_adding_clash(self):
+        super().test_adding_clash()

--- a/wafer/schedule/tests/test_schedule_editor.py
+++ b/wafer/schedule/tests/test_schedule_editor.py
@@ -552,7 +552,7 @@ class ChromeScheduleEditorTests(EditorTestsMixin, ChromeTestRunner):
 
 
 class FirefoxSchedultEditorTests(EditorTestsMixin, FirefoxTestRunner):
-    # We explictly mark the tests we expect due to
+    # We explictly mark the tests we expect to fail due to
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1515879
     # as expectedFailure, so we can run these in github actions
     # with sensible results (and hopefully see when the bug gets


### PR DESCRIPTION
This adds 2 steps to run the selenium tests via github actions against chrome and firefox.

The number of combinations tested is intentionally minimal to keep run times sane.

I couldn't find an existing action to install firefox that looked well maintained, hence the manual installation, but I may well have missed something.