### PR TITLE
Bugfix/redisplay talks after drag over

### DIFF
--- a/wafer/schedule/tests/test_schedule_editor.py
+++ b/wafer/schedule/tests/test_schedule_editor.py
@@ -353,10 +353,8 @@ class EditorTestsMixin:
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element(By.ID, f"scheduleItem{item2.pk}")
 
-    @expectedFailure
     def test_drag_over_talk(self):
         """Test that dragging over an item replaces it"""
-        # Expected to fail - see https://github.com/CTPUG/wafer/issues/689
         # Create a schedule with a single item
         item1 = ScheduleItem.objects.create(venue=self.venues[0],
                                            talk_id=self.talk1.pk)
@@ -403,7 +401,6 @@ class EditorTestsMixin:
             if self.talk2.title in x.text:
                 found2 = True
         self.assertFalse(found2)
-        # FIXME: The schedule editor doesn't do this correctly
         self.assertTrue(found1)
 
     def test_drag_over_page(self):

--- a/wafer/static/js/edit_schedule.js
+++ b/wafer/static/js/edit_schedule.js
@@ -143,6 +143,19 @@
             e.dataTransfer.getData('text/plain'));
         var scheduleItemId = data.getAttribute('data-scheduleitem-id');
         var scheduleItemType = data.getAttribute('data-type');
+
+        var curScheduleItemId = e.target.getAttribute('data-scheduleitem-id');
+        if (curScheduleItemId)
+        {
+            var curType = e.target.getAttribute('data-type');
+            if (curType == 'talk')
+            {
+                // Need to redisplay the talk we're removing
+                var curId = e.target.getAttribute('data-talk-id');
+                var oldUnassigned = document.getElementById("talk" + curId);
+                oldUnassigned.hidden = false;
+            }
+        }
         e.target.innerHTML = data.getAttribute('title');
         e.target.setAttribute('data-scheduleitem-id', scheduleItemId);
         e.target.setAttribute('data-type', scheduleItemType);


### PR DESCRIPTION
This fixe the schedule editor not correctly updatig the 'Unassigned Talks' list when a talk is dropped over an existing entry.

Closes #689 