### PR TITLE
profile: delay jQuery calls until after page is really loaded

### DIFF
--- a/wafer/users/templates/wafer.users/profile.html
+++ b/wafer/users/templates/wafer.users/profile.html
@@ -12,8 +12,9 @@
 {% endblock content %}
 {% block extra_foot %}
 <script type="text/javascript">
-
-  $("#profile-avatar [rel=popover]").attr("data-bs-content", $("#profile-avatar .popover-contents").html());
-  $("a[rel=popover]").popover();
+  $(function() {
+    $("#profile-avatar [rel=popover]").attr("data-bs-content", $("#profile-avatar .popover-contents").html());
+    $("a[rel=popover]").popover();
+  })
 </script>
 {% endblock extra_foot %}


### PR DESCRIPTION
I was getting `$(...).popover is not a function` on the JS console because at the time .popover() is called, probably the other JS bits haven't beed loaded.