### PR TITLE
Make profile urls links, so they're clickable

### DIFF
--- a/wafer/users/templates/wafer.users/snippets/profile_20-bio.html
+++ b/wafer/users/templates/wafer.users/snippets/profile_20-bio.html
@@ -39,10 +39,10 @@
         {% endblock name %}
         {% block social %}
         {% for tag, site_url in social_sites.items %}
-          <p><b>{{ tag }}</b>: {{ site_url }}</p>
+          <p><b>{{ tag }}</b>: <a href="{{ site_url }}">{{ site_url }}</a></p>
         {% endfor %}
         {% for tag, site_url in code_sites.items %}
-          <p><b>{{ tag }}</b>: {{ site_url }}</p>
+          <p><b>{{ tag }}</b>: <a href="{{ site_url }}">{{ site_url }}</a></p>
         {% endfor %}
         {% endblock social %}
         {% endspaceless %}


### PR DESCRIPTION
As a quick fix until we get around to doing something better, this makes adds links to the urls displayed in the profile.