### PR TITLE
Refactor into main workflow and reusable workflow for the tests

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -3,26 +3,7 @@ name: Django CI
 on: [push, pull_request]
 
 jobs:
-  postgres:
-
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-
-    name: Postgres - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == 'main' }} )
+  non-selenium-tests:
     strategy:
       max-parallel: 4
       matrix:
@@ -49,93 +30,10 @@ jobs:
             python-version: '3.12'
           - django-version: '4.1.0'
             python-version: '3.12'
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == 'main' }}
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
-    - name: 'Install psycopg2'
-      run: |
-        pip install psycopg2
-    - name: Install Django Release
-      run: |
-        pip install django~=${{ matrix.django-version }}
-      if: matrix.django-version != 'main'
-    - name: Install Django Main
-      continue-on-error: ${{ matrix.django-version == 'main' }}
-      run: |
-        pip install 'https://github.com/django/django/archive/main.tar.gz'
-      if: matrix.django-version == 'main'
-    - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == 'main' }}
-      env:
-        TESTDB: postgres
-      run: |
-        export PYTHONWARNINGS=always
-        coverage run --source='wafer' manage.py test --exclude-tag selenium && coverage report --skip-covered
-
-  sqlite:
-
-    runs-on: ubuntu-latest
-
-    name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }} (Allowed Failures - ${{ matrix.django-version == 'main'}} )
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2.0', '4.0.0', '4.1.0', '4.2.0', '5.0.0', 'main']
-        exclude:
-          - django-version: '4.2.0'
-            python-version: '3.8'
-          - django-version: 'main'
-            python-version: '3.8'
-          - django-version: 'main'
-            python-version: '3.9'
-          - django-version: '5.0.0'
-            python-version: '3.8'
-          - django-version: '5.0.0'
-            python-version: '3.9'
-          - django-version: '3.2.0'
-            python-version: '3.11'
-          - django-version: '4.0.0'
-            python-version: '3.11'
-          - django-version: '3.2.0'
-            python-version: '3.12'
-          - django-version: '4.0.0'
-            python-version: '3.12'
-          - django-version: '4.1.0'
-            python-version: '3.12'
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      continue-on-error: ${{ matrix.django-version == 'main' }}
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
-    - name: Install Django Release
-      run: |
-        pip install django~=${{ matrix.django-version }}
-      if: matrix.django-version != 'main'
-    - name: Install Django Main
-      continue-on-error: ${{ matrix.django-version == 'main' }}
-      run: |
-        pip install 'https://github.com/django/django/archive/main.tar.gz'
-      if: matrix.django-version == 'main'
-    - name: Run Tests
-      continue-on-error: ${{ matrix.django-version == 'main' }}
-      run: |
-        export PYTHONWARNINGS=always
-        coverage run --source='wafer' manage.py test --exclude-tag selenium && coverage report --skip-covered
+    uses: ./.github/workflows/run_tests.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      django-version: ${{ matrix.django-version }}
 
   translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,91 @@
+name: Run tests against postgres and sqlite
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      django-version:
+        required: true
+        type: string
+
+jobs:
+  run-postgres-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+    name: Postgres - Python ${{ inputs.python-version }}, Django ${{ inputs.django-version }} (Allowed Failures - ${{ inputs.django-version == 'main' }} )
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install Dependencies
+      continue-on-error: ${{ inputs.django-version == 'main' }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+    - name: 'Install psycopg2'
+      run: |
+        pip install psycopg2
+    - name: Install Django Release
+      run: |
+        pip install django~=${{ inputs.django-version }}
+      if: inputs.django-version != 'main'
+    - name: Install Django Main
+      continue-on-error: ${{ inputs.django-version == 'main' }}
+      run: |
+        pip install 'https://github.com/django/django/archive/main.tar.gz'
+      if: inputs.django-version == 'main'
+    - name: Run Tests
+      continue-on-error: ${{ inputs.django-version == 'main' }}
+      env:
+        TESTDB: postgres
+      run: |
+        export PYTHONWARNINGS=always
+        coverage run --source='wafer' manage.py test --exclude-tag selenium && coverage report --skip-covered
+
+  run-sqlite-tests:
+    runs-on: ubuntu-latest
+    name: SQLite - Python ${{ inputs.python-version }}, Django ${{ inputs.django-version }} (Allowed Failures - ${{ inputs.django-version == 'main'}} )
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install Dependencies
+      continue-on-error: ${{ inputs.django-version == 'main' }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+    - name: Install Django Release
+      run: |
+        pip install django~=${{ inputs.django-version }}
+      if: inputs.django-version != 'main'
+    - name: Install Django Main
+      continue-on-error: ${{ inputs.django-version == 'main' }}
+      run: |
+        pip install 'https://github.com/django/django/archive/main.tar.gz'
+      if: inputs.django-version == 'main'
+    - name: Run Tests
+      continue-on-error: ${{ inputs.django-version == 'main' }}
+      run: |
+        export PYTHONWARNINGS=always
+        coverage run --source='wafer' manage.py test --exclude-tag selenium && coverage report --skip-covered


### PR DESCRIPTION
The duplicated matrix for sqlite and postgres is a pain to maintain, but github doesn't yaml anchors and aliases, which would be the usual way to solve this

Gitub does support reusable actions, though, which does allow us to unify the two matrixes at the cost of splitting the workflow into two files, which is not still not great, but is better.