### PR TITLE
Feature/add readthedocs yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ nosetests.xml
 /wafer.db
 /media/
 /wafer/static/vendor/
+
+# Selenium log files
+geckodriver.log

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+  python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - pdf


### PR DESCRIPTION
Readthedocs changed things a while ago, and we never updated wafer to match, so out docs builds have been failing for a while
- see https://readthedocs.org/projects/wafer/builds/23673439/ for example

This adds a minimal readthedocs.yml file which I think should solve the issue.