### PR TITLE
Feature/update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,10 @@ wafer
 
 |wafer-ci-badge| |wafer-docs-badge| |wafer-weblate-badge|
 
-.. |wafer-ci-badge| image:: https://travis-ci.org/CTPUG/wafer.png?branch=master
-    :alt: Travis CI build status
+.. |wafer-ci-badge| image:: https://github.com/CTPUG/wafer/actions/workflows/django.yml/badge.svg
+    :alt: Github actions CI build status
     :scale: 100%
-    :target: https://travis-ci.org/CTPUG/wafer
+    :target: https://github.com/CTPUG/wafer/actions/
 
 .. |wafer-docs-badge| image:: https://readthedocs.org/projects/wafer/badge/?version=latest
     :alt: Wafer documentation

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Available on `readthedocs.org`_.
 Supported Django versions
 =========================
 
-Wafer supports Django 3.2 and Django 4.0 - 4.2.
+Wafer supports Django 3.2, Django 4.0 - 4.2 and Django 5.0 .
 
 Installation
 ============

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Supported versions
 ==================
 
-Wafer supports Django 3.2, 4.0-4.2 and Python 3.7 to 3.11.
+Wafer supports Django 3.2, 4.0-4.2, 5.0 and Python 3.8 to 3.12.
 
 Requirements
 ============

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import subprocess
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=3.2,<5',
+    'Django>=3.2,<5.1',
     'bleach',
     'bleach-allowlist',
     'crispy-bootstrap5',


### PR DESCRIPTION
Update the documentation and dependencies to allow Django 5.0 (since we test against it now)

Also fix the build badge to point to the github actions one