### PR TITLE
Wrap registered / ticket info in it's own section

### DIFF
--- a/wafer/users/templates/wafer.users/snippets/profile_30-registered.html
+++ b/wafer/users/templates/wafer.users/snippets/profile_30-registered.html
@@ -3,28 +3,30 @@
   {% if can_edit %}
     {% if profile.pending_talks.exists or profile.accepted_talks.exists or profile.provisional_talks.exists%}
       {% block speaker_registered %}
-        {% if profile.is_registered %}
-          <div class="alert alert-success">
-            {% blocktrans trimmed %}
-              Registered
-            {% endblocktrans %}
-          </div>
-        {% else %}
-          <div class="alert alert-danger">
-            {% blocktrans trimmed %}
-              <strong>WARNING:</strong>
-              Talk proposal submitted, but speaker hasn't registered to attend.
-            {% endblocktrans %}
-            {% if WAFER_REGISTRATION_OPEN %}
-              {% trans "Register now!" %}
-            {% endif %}
-          </div>
-        {% endif %}
-        {% if WAFER_REGISTRATION_MODE == 'ticket' and profile.is_registered %}
-          <p>Tickets:
-            {{ profile.ticket_types }}
-          </p>
-        {% endif %}
+        <section class="wafer-profile-registered">
+          {% if profile.is_registered %}
+            <div class="alert alert-success">
+              {% blocktrans trimmed %}
+                Registered
+              {% endblocktrans %}
+            </div>
+          {% else %}
+            <div class="alert alert-danger">
+              {% blocktrans trimmed %}
+                <strong>WARNING:</strong>
+                Talk proposal submitted, but speaker hasn't registered to attend.
+              {% endblocktrans %}
+              {% if WAFER_REGISTRATION_OPEN %}
+                {% trans "Register now!" %}
+              {% endif %}
+            </div>
+          {% endif %}
+          {% if WAFER_REGISTRATION_MODE == 'ticket' and profile.is_registered %}
+            <p>Tickets:
+              {{ profile.ticket_types }}
+            </p>
+          {% endif %}
+        </section>
       {% endblock speaker_registered %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
When the profile was refactored into snippets, the 'speaker isn't registered' block didn't get a surrounding ```<section>```, unlike the other snippets.

This leads to the warning being rendered over the bio, rather than below it, which is undesirable. (This didn't happen previously, because stuff was in a common section)

This wraps stuff in it's own section, for consistency with the other snippets and to avoid the rendering issues.