### PR TITLE
Pin django rest framework to the last version that supports Django < 4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ REQUIRES = [
     'django-registration-redux',
     'django-reversion',
     'django-select2',
-    'djangorestframework',
+    'djangorestframework<3.15.2',
     'drf-extensions>=0.5.0',
     'icalendar>=4.0',
     'jsonfield',


### PR DESCRIPTION
This is a quick fix so our CI works again.