### PR TITLE
Feature/sort talks page

### DIFF
--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -18,14 +18,28 @@
         <thead class='thead-dark'>
           <tr>
             <th>
-              {% if type %}
-                {{ type }}
-              {% else %}
-                {% trans "Talk" %}
-              {% endif %}
+               <a href="{% url 'wafer_users_talks' %}?sort={% if sort == 'title' %}default{% else %}title{% endif %}">
+                {% if type %}
+                  {{ type }}
+                {% else %}
+                  {% trans "Talk" %}
+                {% endif %}
+              </a>
             </th>
-            {% if tracks %}<th>{% trans "Track" %}</th>{% endif %}
-            {% if languages %}<th>{% trans "Language" %}</th>{% endif %}
+            {% if tracks %}
+              <th>
+                 <a href="{% url 'wafer_users_talks' %}?sort={% if sort == 'track' %}default{% else %}track{% endif %}">
+                  {% trans "Track" %}
+                </a>
+              </th>
+            {% endif %}
+            {% if languages %}
+              <th>
+                 <a href="{% url 'wafer_users_talks' %}?sort={% if sort == 'lang' %}default{% else %}lang{% endif %}">
+                  {% trans "Language" %}
+                </a>
+              </th>
+            {% endif %}
             <th>{% trans "Speakers" %}</th>
           </tr>
         </thead>

--- a/wafer/talks/templates/wafer.talks/talks.html
+++ b/wafer/talks/templates/wafer.talks/talks.html
@@ -104,15 +104,15 @@
   <section class="wafer wafer-pagination">
     <ul class="pagination">
       {% if page_obj.has_previous %}
-        <li class="page-item"><a class="page-link" href="{% url 'wafer_users_talks_page' page=page_obj.previous_page_number %}">&laquo;</a></li>
+        <li class="page-item"><a class="page-link" href="{% url 'wafer_users_talks_page' page=page_obj.previous_page_number %}?sort={{ sort }}">&laquo;</a></li>
       {% else %}
         <li class="page-item" class="disabled"><a class="page-link" href="#">&laquo;</a></li>
       {% endif %}
       {% for page in paginator.page_range %}
-        <li class="page-item"><a class="page-link" href="{% url 'wafer_users_talks_page' page=page %}">{{ page }}</a></li>
+        <li class="page-item"><a class="page-link" href="{% url 'wafer_users_talks_page' page=page %}?sort={{ sort }}">{{ page }}</a></li>
       {% endfor %}
       {% if page_obj.has_next %}
-        <li class="page-item"><a class="page-link" href="{% url 'wafer_users_talks_page' page=page_obj.next_page_number %}">&raquo;</a></li>
+        <li class="page-item"><a class="page-link" href="{% url 'wafer_users_talks_page' page=page_obj.next_page_number %}?sort={{ sort }}">&raquo;</a></li>
       {% else %}
         <li class="page-item" class="disabled"><a class="page-link" href="#">&raquo;</a></li>
       {% endif %}

--- a/wafer/talks/tests/fixtures.py
+++ b/wafer/talks/tests/fixtures.py
@@ -7,7 +7,8 @@ def create_talk_type(name, **kwargs):
     return TalkType.objects.create(name=name, **kwargs)
 
 
-def create_talk(title, status, username=None, user=None, talk_type=None):
+def create_talk(title, status, username=None, user=None, talk_type=None,
+                talk_track=None, language=None):
     if sum((user is None, username is None)) != 1:
         raise ValueError('One of user OR username must be specified')
     if username:
@@ -20,5 +21,11 @@ def create_talk(title, status, username=None, user=None, talk_type=None):
     talk.save()
     if talk_type:
         talk.talk_type = talk_type
+        talk.save()
+    if talk_track:
+        talk.track = talk_track
+        talk.save()
+    if language:
+        talk.language = language
         talk.save()
     return talk

--- a/wafer/talks/tests/test_views.py
+++ b/wafer/talks/tests/test_views.py
@@ -190,13 +190,25 @@ class TalksListSortingTests(TestCase):
         """Ensure Talk monkey-patching doesn't leak"""
         Talk.LANGUAGES = ()
 
-    def test_sort_title(self):
-        response = self.client.get('/talks/?sort=title')
+    def test_no_sorting(self):
+        response = self.client.get('/talks/')
         # We check via find to avoid hardcoding too much HTML here
         pos_talk_a = response.content.find(b'Talk A')
         pos_talk_b = response.content.find(b'Talk B')
         pos_talk_c = response.content.find(b'Talk C')
         pos_talk_d = response.content.find(b'Talk D')
+        # Order should be D, C, B, A (id order)
+        self.assertGreater(pos_talk_a, pos_talk_b)
+        self.assertGreater(pos_talk_b, pos_talk_c)
+        self.assertGreater(pos_talk_c, pos_talk_d)
+
+    def test_sort_title(self):
+        response = self.client.get('/talks/?sort=title')
+        pos_talk_a = response.content.find(b'Talk A')
+        pos_talk_b = response.content.find(b'Talk B')
+        pos_talk_c = response.content.find(b'Talk C')
+        pos_talk_d = response.content.find(b'Talk D')
+        # Should be A, B, C, D
         self.assertGreater(pos_talk_b, pos_talk_a)
         self.assertGreater(pos_talk_c, pos_talk_b)
         self.assertGreater(pos_talk_d, pos_talk_c)

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -77,6 +77,10 @@ class UsersTalks(PaginatedBuildableListView):
         context["languages"] = Talk.LANGUAGES
         context["tracks"] = Track.objects.count() > 0
         context["see_all"] = Talk.can_view_all(self.request.user)
+        if self.request.GET.get('sort'):
+            context['sort'] = self.request.GET.get('sort')
+        else:
+            context['sort'] = 'default'
         return context
 
 

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -45,7 +45,6 @@ class UsersTalks(PaginatedBuildableListView):
     build_prefix = 'talks'
     paginate_by = 100
 
-    @order_results_by('talk_type', 'talk_id')
     def get_queryset(self):
         # self.request will be None when we come here via the static site
         # renderer
@@ -57,8 +56,20 @@ class UsersTalks(PaginatedBuildableListView):
                 | Q(status__in=(SUBMITTED, UNDER_CONSIDERATION, PROVISIONAL),
                     talk_type__show_pending_submissions=True)
             )
+        if self.request:
+            if self.request.GET.get('sort') == 'track' and Track.objects.count() > 0:
+                talks = talks.order_by('talk_type', 'track')
+            elif self.request.GET.get('sort') == 'lang' and Talk.LANGUAGES:
+                talks = talks.order_by('talk_type', 'language')
+            elif self.request.GET.get('sort') == 'title':
+                talks = talks.order_by('talk_type', 'title')
+            else:
+                talks = talks.order_by('talk_type', 'talk_id')
+        else:
+            talks = talks.order_by('talk_type', 'talk_id')
         return talks.prefetch_related(
-            "talk_type", "corresponding_author", "authors", "authors__userprofile"
+            "talk_type", "corresponding_author", "authors", "authors__userprofile",
+            "track"
         )
 
     def get_context_data(self, **kwargs):

--- a/wafer/talks/views.py
+++ b/wafer/talks/views.py
@@ -77,10 +77,7 @@ class UsersTalks(PaginatedBuildableListView):
         context["languages"] = Talk.LANGUAGES
         context["tracks"] = Track.objects.count() > 0
         context["see_all"] = Talk.can_view_all(self.request.user)
-        if self.request.GET.get('sort'):
-            context['sort'] = self.request.GET.get('sort')
-        else:
-            context['sort'] = 'default'
+        context['sort'] = self.request.GET.get('sort', 'default')
         return context
 
 


### PR DESCRIPTION
This adds support for sorting the talks list by track, language or title.

We add links to the table headers to switch sorting. 

Sorting is currently global, although it can be triggered on any of the tables created by using multiple talk types, but I don't think the complexity of sorting within a type only is worthwhile.

Closes #710 

