### PR TITLE
talks: configure maximum number of talk authors to list explicitly

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -128,6 +128,12 @@ Wafer's settings
     When ``True``, users can register for the conference.
     (Note, this is not the same as signing up for an account on the website.)
 
+``WAFER_SCHEDULE_MAX_AUTHORS``
+   A number.
+   This is the maximum list of people to be listed as talk authors in the
+   schedule. If the number of talk authors is higher than this, then they get
+   displayed as "First Author, et al."
+
 ``WAFER_SSO``
     A list of SSO mechanisms in use.
     Possible options are: ``'github'``, ``'gitlab'``.

--- a/wafer/settings.py
+++ b/wafer/settings.py
@@ -362,3 +362,7 @@ CODE_HOSTING_ENTRIES = {
 
 # Hide the schedule from users without permission to edit it
 WAFER_HIDE_SCHEDULE = False
+
+# Number of talk authors to list explicitly, before listing them as "First
+# Author, et al."
+WAFER_SCHEDULE_MAX_AUTHORS = 2

--- a/wafer/talks/models.py
+++ b/wafer/talks/models.py
@@ -283,7 +283,7 @@ class Talk(models.Model):
             key=lambda author: u'' if author == self.corresponding_author
                                else author.userprofile.display_name())
         names = [author.userprofile.display_name() for author in authors]
-        if len(names) <= 2:
+        if len(names) <= settings.WAFER_SCHEDULE_MAX_AUTHORS:
             return u' & '.join(names)
         return _(u'%s, et al.') % names[0]
 


### PR DESCRIPTION
I have been using wafer instances for single-track events, where there is plenty of space in the schedule to just list all authors. This will let me configure my instances to list a higher number than 2.