### PR TITLE
Feature/update test matrix

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -7,29 +7,27 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2.0', '4.0.0', '4.1.0', '4.2.0', '5.0.0', 'main']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        django-version: ['4.2.0', '5.0.0', '5.1.0', 'main']
         exclude:
           - django-version: '4.2.0'
-            python-version: '3.8'
-          - django-version: 'main'
-            python-version: '3.8'
-          - django-version: 'main'
-            python-version: '3.9'
+            python-version: '3.13'
           - django-version: '5.0.0'
             python-version: '3.8'
           - django-version: '5.0.0'
             python-version: '3.9'
-          - django-version: '3.2.0'
+          - django-version: '5.1.0'
+            python-version: '3.8'
+          - django-version: '5.1.0'
+            python-version: '3.9'
+          - django-version: 'main'
+            python-version: '3.8'
+          - django-version: 'main'
+            python-version: '3.9'
+          - django-version: 'main'
+            python-version: '3.10'
+          - django-version: 'main'
             python-version: '3.11'
-          - django-version: '4.0.0'
-            python-version: '3.11'
-          - django-version: '3.2.0'
-            python-version: '3.12'
-          - django-version: '4.0.0'
-            python-version: '3.12'
-          - django-version: '4.1.0'
-            python-version: '3.12'
     uses: ./.github/workflows/run_tests.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import subprocess
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    'Django>=3.2,<5.1',
+    'Django>=4.2,<5.2',
     'bleach',
     'bleach-allowlist',
     'crispy-bootstrap5',
@@ -15,7 +15,7 @@ REQUIRES = [
     'django-registration-redux',
     'django-reversion',
     'django-select2',
-    'djangorestframework<3.15.2',
+    'djangorestframework',
     'drf-extensions>=0.5.0',
     'icalendar>=6.0',
     'jsonfield',


### PR DESCRIPTION
Since more of our dependencies have dropped support for Django < 4.2, there seems little point in continuing to fight the march of progress. This PR updates the test matrix to just the currently supported Django set and also removes the pin on django-restframework we added when that dropped support for Django < 4.2.