### PR TITLE
Update the import_quicket_ticket list command to current Django argument parsing

### DIFF
--- a/wafer/tickets/management/commands/import_quicket_guest_list.py
+++ b/wafer/tickets/management/commands/import_quicket_guest_list.py
@@ -7,27 +7,25 @@ from wafer.tickets.views import import_ticket
 
 
 class Command(BaseCommand):
-    args = '<csv file>'
-    help = "Import a guest list CSV from Quicket"
+
+    def add_arguments(self, parser):
+        """Add a required file input"""
+        parser.add_argument('csv_file', help="Import a guest list CSV from Quicket")
 
     def handle(self, *args, **options):
-        if len(args) != 1:
-            raise CommandError('1 CSV File required')
-
+        csv_file = options['csv_file']
         logging.basicConfig(level=logging.INFO)
 
-        columns = ('Ticket Number', 'Ticket Barcode', 'Purchase Date',
-                   'Ticket Type', 'Ticket Holder', 'Email', 'Cellphone',
-                   'Checked in', 'Checked in date', 'Checked in by',
-                   'Complimentary')
-        keys = [column.lower().replace(' ', '_') for column in columns]
+        required_keys = ['ticket_barcode', 'ticket_type', 'email']
 
-        with open(args[0], 'r') as f:
+        with open(csv_file, 'r') as f:
             reader = csv.reader(f)
 
             header = tuple(next(reader))
-            if header != columns:
-                raise CommandError('CSV format has changed. Update wafer')
+            keys = [column.lower().replace(' ', '_') for column in header]
+            for expected_key in required_keys:
+                if expected_key not in keys:
+                    raise CommandError('CSV format has changed. Update wafer')
 
             for row in reader:
                 ticket = dict(zip(keys, row))


### PR DESCRIPTION
The import_quicket_list command doesn't currently work, due to using outdated argument parsing.

This also relaxes the CSV checks, as the current quicket CSV export includes checkout questions as headers, and so the headers are now conference setup specific, so it seems better to just check that the headers we require are there, rather than requiring each conference to update the columns field to match their export file.