### PR TITLE
Fix translation typo in pt and pt_BR: ativade -> ativada

### DIFF
--- a/wafer/locale/pt/LC_MESSAGES/django.po
+++ b/wafer/locale/pt/LC_MESSAGES/django.po
@@ -246,7 +246,7 @@ msgstr "Ativação completa"
 msgid ""
 "Your account is now activated! Please <a href=\"%(login_url)s\">log in</a>."
 msgstr ""
-"A sua conta foi ativade! Por favor, <a href=\"%(login_url)s\">inicia sessão</"
+"A sua conta foi ativada! Por favor, <a href=\"%(login_url)s\">inicia sessão</"
 "a>."
 
 #: wafer/registration/templates/registration/activation_complete.html:13

--- a/wafer/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wafer/locale/pt_BR/LC_MESSAGES/django.po
@@ -240,7 +240,7 @@ msgstr "Ativação completa"
 msgid ""
 "Your account is now activated! Please <a href=\"%(login_url)s\">log in</a>."
 msgstr ""
-"Sua conta foi ativade! Por favor, <a href=\"%(login_url)s\">inicia sessão</"
+"Sua conta foi ativada! Por favor, <a href=\"%(login_url)s\">inicia sessão</"
 "a>."
 
 #: wafer/registration/templates/registration/activation_complete.html:13


### PR DESCRIPTION
Reported-By: Matheus Polkorny <polkorny@disroot.org>