### PR TITLE
find_speaker_clashes: avoid crash without a talk or a page

### DIFF
--- a/wafer/schedule/admin.py
+++ b/wafer/schedule/admin.py
@@ -116,6 +116,8 @@ def find_speaker_clashes(all_items):
             speakers = list(item.talk.authors.all())
         elif item.page:
             speakers = list(item.page.people.all())
+        else:
+            speakers = []
         for speaker in speakers:
             for slot in item.slots.all():
                 candidate = (slot, speaker)


### PR DESCRIPTION
If a user creates a schedule item and adds them to the schedule before associating a talk or a page, this causes a crash, because `speakers` will not be defined.

    UnboundLocalError: cannot access local variable 'speakers' where it
    is not associated with a value