### PR TITLE
penta XML: Opt-out from video on pages by default

### DIFF
--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -76,6 +76,7 @@
                             <license>{{ WAFER_VIDEO_LICENSE }}</license>
                           {% else %}
                             <optout>true</optout>
+                            <license/>
                           {% endif %}
                         </recording>
                       {% endwith %}
@@ -108,6 +109,7 @@
                       {% endif %}
                       <recording>
                         <optout>true</optout>
+                        <license/>
                       </recording>
                     {% endif %}
                     <url>https://{{ WAFER_CONFERENCE_DOMAIN }}{{ items.item.get_url }}</url>

--- a/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
+++ b/wafer/schedule/templates/wafer.schedule/penta_schedule.xml
@@ -107,8 +107,7 @@
                         <description/>
                       {% endif %}
                       <recording>
-                        <optout>false</optout>
-                        <license>{{ WAFER_VIDEO_LICENSE }}</license>
+                        <optout>true</optout>
                       </recording>
                     {% endif %}
                     <url>https://{{ WAFER_CONFERENCE_DOMAIN }}{{ items.item.get_url }}</url>


### PR DESCRIPTION
Typically we use pages for meals, and that means that they have always been marked as having video at DebConf.

Flip this to not having video. It's rare for something that's a page to have video coverage.

Obviously this is not perfect, it's replacing an assumption with a better one, see #615 and #384 for discussion on really improving this.